### PR TITLE
Update bitmap-allocator

### DIFF
--- a/kernel-hal-bare/Cargo.toml
+++ b/kernel-hal-bare/Cargo.toml
@@ -11,7 +11,7 @@ description = "Kernel HAL implementation for bare metal environment."
 log = "0.4"
 spin = "0.5"
 executor = { git = "https://github.com/PanQL/executor.git", rev="c86db90" }
-trapframe = "0.1.6"
+trapframe = "0.1.7"
 kernel-hal = { path = "../kernel-hal" }
 naive-timer= { git = "https://github.com/rcore-os/naive-timer.git", rev="cd44f4c" }
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -9,6 +9,6 @@ description = "Kernel HAL interface definations."
 
 [dependencies]
 bitflags = "1.2"
-trapframe = "0.1.6"
+trapframe = "0.1.7"
 git-version = "0.3"
 numeric-enum-macro = "0.2"

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -12,17 +12,16 @@ graphic = []
 [dependencies]
 log = "0.4"
 spin = "0.5"
-buddy_system_allocator = "0.3.9"
+buddy_system_allocator = "0.4.0"
 rlibc = "1.0"
 rboot = { path = "../rboot", default-features = false }
 kernel-hal-bare = { path = "../kernel-hal-bare" }
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }
-bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator" }
-trapframe = "0.1.6"
-executor = { git = "https://github.com/PanQL/executor.git", rev="c86db90" }
+bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "03bd9909" }
+trapframe = "0.1.7"
+executor = { git = "https://github.com/PanQL/executor.git", rev = "c86db90" }
 zircon-loader = { path = "../zircon-loader", default-features = false }
 zircon-object = { path = "../zircon-object" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.10"
-uart_16550 = "0.2"


### PR DESCRIPTION
* Update dependency `bitmap-allocator`. LOCK its version.
  Fix the page allocation order.
* Increase kernel heap size to 16MB
* Remove heap rescue since it no longer fits the new version allocator.