### PR TITLE
Optimize: replace rlibc by our optimized version

### DIFF
--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -13,7 +13,7 @@ graphic = []
 log = "0.4"
 spin = "0.5"
 buddy_system_allocator = "0.4.0"
-rlibc = "1.0"
+rlibc-opt = { git = "https://github.com/rcore-os/rlibc-opt.git", rev = "0ab1d1e" }
 rboot = { path = "../rboot", default-features = false }
 kernel-hal-bare = { path = "../kernel-hal-bare" }
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -9,7 +9,7 @@
 extern crate alloc;
 #[macro_use]
 extern crate log;
-extern crate rlibc;
+extern crate rlibc_opt;
 
 #[macro_use]
 mod logging;


### PR DESCRIPTION
Currently rCore/zCore use [rlibc](https://docs.rs/rlibc/1.0.0/rlibc/) crate to provide intrinsics such as `memcpy`, `memset`.

But its implementation is not optimized at all, and we found the performance is terrible.
In VMO microbenchmark, kernel R/W is x5 slower than user space. See results [here](https://github.com/rcore-os/zCore/wiki/Status:-Microbenchmarks/181e8a3645c823127d15ac748f46b871567ce5f5)

This PR replaces rlibc by our optimized version, where the code is borrowed from musl-libc.
After this optimization, the performance in kernel is similar to user space. See [new results](https://github.com/rcore-os/zCore/wiki/Status:-Microbenchmarks/1dbdfbd9ca9473323382cdf42d8381e32341b416).
