### PR TITLE
Optimize CI time and LFS bandwidth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        lfs: true
+    - name: Pull prebuilt images
+      run: git lfs pull -X prebuilt/zircon/bringup.zbi
     - name: Prepare rootfs
       run: make rootfs
     - name: Test
@@ -88,7 +88,12 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ steps.coverage.outputs.report }}
-    - name: Run benchmarks
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
+
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench

--- a/kernel-hal-bare/Cargo.toml
+++ b/kernel-hal-bare/Cargo.toml
@@ -17,8 +17,8 @@ naive-timer= { git = "https://github.com/rcore-os/naive-timer.git", rev="cd44f4c
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = "0.10"
-uart_16550 = "0.2.5"
+x86_64 = "0.11"
+uart_16550 = "0.2.6"
 raw-cpuid = "7.0"
 pc-keyboard = "0.5"
 apic = { git = "https://github.com/rcore-os/apic-rs", rev = "01cf01a" }

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -24,4 +24,4 @@ zircon-loader = { path = "../zircon-loader", default-features = false }
 zircon-object = { path = "../zircon-object" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-x86_64 = "0.10"
+x86_64 = "0.11"


### PR DESCRIPTION
* Don't pull unused large image.
  To save Git LFS bandwidth and save my money.
* Separate benchmark to save CI time: 9min -> 7min.
* Remove hack of page table USER bit.
  Update x86_64 crate to v0.11.