### PR TITLE
Fix the "\r" problem in build.rs file of zircon-syscall crate

### DIFF
--- a/zircon-syscall/build.rs
+++ b/zircon-syscall/build.rs
@@ -13,7 +13,7 @@ fn main() {
     writeln!(fout, "pub enum SyscallType {{").unwrap();
 
     let data = std::fs::read_to_string("src/zx-syscall-numbers.h").unwrap();
-    for line in data.split('\n') {
+    for line in data.lines() {
         if !line.starts_with("#define") {
             continue;
         }


### PR DESCRIPTION
If this repo is cloned on Windows, Line ends in `zx-syscall-numbers.h` file will be "\r\n". Current `build.rs` building script creates unwanted line breaks in this situation. This PR fix this issue.