### PR TITLE
Makes zx_object_get_info returns ZX_ERR_BUFFER_TOO_SMALL

### DIFF
--- a/zircon-syscall/src/object.rs
+++ b/zircon-syscall/src/object.rs
@@ -220,28 +220,46 @@ impl Syscall<'_> {
                 let _ = proc.get_dyn_object_with_rights(handle, Rights::empty())?;
             }
             Topic::Process => {
+                if buffer_size < core::mem::size_of::<ProcessInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let proc = proc.get_object_with_rights::<Process>(handle, Rights::INSPECT)?;
                 UserOutPtr::<ProcessInfo>::from(buffer).write(proc.get_info())?;
             }
             Topic::Vmar => {
+                if buffer_size < core::mem::size_of::<VmarInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let vmar =
                     proc.get_object_with_rights::<VmAddressRegion>(handle, Rights::INSPECT)?;
                 UserOutPtr::<VmarInfo>::from(buffer).write(vmar.get_info())?;
             }
             Topic::HandleBasic => {
+                if buffer_size < core::mem::size_of::<HandleBasicInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let info = proc.get_handle_info(handle)?;
                 UserOutPtr::<HandleBasicInfo>::from(buffer).write(info)?;
             }
             Topic::Thread => {
+                if buffer_size < core::mem::size_of::<ThreadInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let thread = proc.get_object_with_rights::<Thread>(handle, Rights::INSPECT)?;
                 UserOutPtr::<ThreadInfo>::from(buffer).write(thread.get_thread_info())?;
             }
             Topic::HandleCount => {
+                if buffer_size < core::mem::size_of::<u32>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let object = proc.get_dyn_object_with_rights(handle, Rights::INSPECT)?;
                 // FIXME: count Handle instead of Arc
                 UserOutPtr::<u32>::from(buffer).write(Arc::strong_count(&object) as u32 - 1)?;
             }
             Topic::Job => {
+                if buffer_size < core::mem::size_of::<JobInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let job = proc.get_object_with_rights::<Job>(handle, Rights::INSPECT)?;
                 UserOutPtr::<JobInfo>::from(buffer).write(job.get_info())?;
             }
@@ -251,6 +269,9 @@ impl Syscall<'_> {
                 avail.write(0)?;
             }
             Topic::Vmo => {
+                if buffer_size < core::mem::size_of::<VmoInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let (vmo, rights) = proc.get_object_and_rights::<VmObject>(handle)?;
                 let mut info = vmo.get_info();
                 info.flags |= VmoInfoFlags::VIA_HANDLE;
@@ -258,12 +279,17 @@ impl Syscall<'_> {
                 UserOutPtr::<VmoInfo>::from(buffer).write(info)?;
             }
             Topic::KmemStats => {
+                if buffer_size < core::mem::size_of::<KmemInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let mut kmem = KmemInfo::default();
                 kmem.vmo_bytes = vmo_page_bytes() as u64;
                 UserOutPtr::<KmemInfo>::from(buffer).write(kmem)?;
             }
             Topic::TaskStats => {
-                assert_eq!(core::mem::size_of::<TaskStatsInfo>(), buffer_size);
+                if buffer_size < core::mem::size_of::<TaskStatsInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let vmar = proc
                     .get_object_with_rights::<Process>(handle, Rights::INSPECT)?
                     .vmar();
@@ -290,15 +316,24 @@ impl Syscall<'_> {
                 avail.write(ids.len())?;
             }
             Topic::Bti => {
+                if buffer_size < core::mem::size_of::<BtiInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let bti = proc
                     .get_object_with_rights::<BusTransactionInitiator>(handle, Rights::INSPECT)?;
                 UserOutPtr::<BtiInfo>::from(buffer).write(bti.get_info())?;
             }
             Topic::Resource => {
+                if buffer_size < core::mem::size_of::<ResourceInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let resource = proc.get_object_with_rights::<Resource>(handle, Rights::INSPECT)?;
                 UserOutPtr::<ResourceInfo>::from(buffer).write(resource.get_info())?;
             }
             Topic::Socket => {
+                if buffer_size < core::mem::size_of::<SocketInfo>() {
+                    return Err(ZxError::BUFFER_TOO_SMALL);
+                }
                 let socket = proc.get_object_with_rights::<Socket>(handle, Rights::INSPECT)?;
                 UserOutPtr::<SocketInfo>::from(buffer).write(socket.get_info())?;
             }


### PR DESCRIPTION
[Arccording to the syscall rederence](https://fuchsia.dev/fuchsia-src/reference/syscalls/object_get_info#errors), zx_object_get_info should returns the error `ZX_ERR_BUFFER_TOO_SMALL` when the `topic` returns a fixed number of records, but the provided buffer is not large enough for these records. This PR implemented this.
After this PR, the zircon core test `HandleInfoTest.DupAndInfoRights` will no longer fail.