### PR TITLE
Optimize performance of microbenchmarks

### DIFF
--- a/kernel-hal-bare/Cargo.toml
+++ b/kernel-hal-bare/Cargo.toml
@@ -11,7 +11,7 @@ description = "Kernel HAL implementation for bare metal environment."
 log = "0.4"
 spin = "0.5"
 executor = { git = "https://github.com/PanQL/executor.git", rev="c86db90" }
-trapframe = "0.1.7"
+trapframe = "0.2.0"
 kernel-hal = { path = "../kernel-hal" }
 naive-timer= { git = "https://github.com/rcore-os/naive-timer.git", rev="cd44f4c" }
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }

--- a/kernel-hal-bare/src/lib.rs
+++ b/kernel-hal-bare/src/lib.rs
@@ -49,8 +49,6 @@ extern "C" {
     fn hal_pt_map_kernel(pt: *mut u8, current: *const u8);
     fn hal_frame_alloc() -> Option<PhysAddr>;
     fn hal_frame_dealloc(paddr: &PhysAddr);
-    #[allow(dead_code)]
-    fn hal_frame_alloc_contiguous(size: usize, align_log2: usize) -> Option<PhysAddr>;
     #[link_name = "hal_pmem_base"]
     static PMEM_BASE: usize;
 }

--- a/kernel-hal-unix/src/lib.rs
+++ b/kernel-hal-unix/src/lib.rs
@@ -66,9 +66,7 @@ task_local! {
 
 #[export_name = "hal_context_run"]
 unsafe fn context_run(context: &mut UserContext) {
-    core::arch::x86_64::_fxrstor64(&context.vector as *const VectorRegs as _);
     trap::run_user(&mut context.general);
-    core::arch::x86_64::_fxsave64(&mut context.vector as *mut VectorRegs as _);
     // cause: syscall
     context.trap_num = 0x100;
 }

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -9,6 +9,6 @@ description = "Kernel HAL interface definations."
 
 [dependencies]
 bitflags = "1.2"
-trapframe = "0.1.7"
+trapframe = "0.2.0"
 git-version = "0.3"
 numeric-enum-macro = "0.2"

--- a/kernel-hal/src/context.rs
+++ b/kernel-hal/src/context.rs
@@ -1,0 +1,47 @@
+use core::fmt;
+
+#[repr(C, align(16))]
+#[derive(Debug, Copy, Clone)]
+pub struct VectorRegs {
+    pub fcw: u16,
+    pub fsw: u16,
+    pub ftw: u8,
+    pub _pad0: u8,
+    pub fop: u16,
+    pub fip: u32,
+    pub fcs: u16,
+    pub _pad1: u16,
+
+    pub fdp: u32,
+    pub fds: u16,
+    pub _pad2: u16,
+    pub mxcsr: u32,
+    pub mxcsr_mask: u32,
+
+    pub mm: [U128; 8],
+    pub xmm: [U128; 16],
+    pub reserved: [U128; 3],
+    pub available: [U128; 3],
+}
+
+// https://xem.github.io/minix86/manual/intel-x86-and-64-manual-vol1/o_7281d5ea06a5b67a-274.html
+impl Default for VectorRegs {
+    fn default() -> Self {
+        VectorRegs {
+            fcw: 0x37f,
+            mxcsr: 0x1f80,
+            ..unsafe { core::mem::zeroed() }
+        }
+    }
+}
+
+// workaround: libcore has bug on Debug print u128 ??
+#[derive(Default, Clone, Copy)]
+#[repr(C, align(16))]
+pub struct U128(pub [u64; 2]);
+
+impl fmt::Debug for U128 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#016x}{:016x}", self.0[1], self.0[0])
+    }
+}

--- a/kernel-hal/src/lib.rs
+++ b/kernel-hal/src/lib.rs
@@ -39,12 +39,14 @@ pub mod defs {
     pub const PAGE_SIZE: usize = 0x1000;
 }
 
+mod context;
 mod dummy;
 mod future;
 pub mod user;
 pub mod vdso;
 
+pub use self::context::*;
 pub use self::defs::*;
 pub use self::dummy::*;
 pub use self::future::*;
-pub use trapframe::{GeneralRegs, UserContext, VectorRegs};
+pub use trapframe::{GeneralRegs, UserContext};

--- a/linux-object/Cargo.toml
+++ b/linux-object/Cargo.toml
@@ -11,6 +11,7 @@ description = "Linux kernel objects"
 log = "0.4"
 spin = "0.5"
 xmas-elf = "0.7"
+hashbrown = "0.7"
 zircon-object = { path = "../zircon-object", features = ["elf"] }
 kernel-hal = { path = "../kernel-hal" }
 downcast-rs = { git = "https://github.com/rcore-os/downcast-rs" }

--- a/linux-object/src/fs/mod.rs
+++ b/linux-object/src/fs/mod.rs
@@ -41,7 +41,7 @@ pub trait FileLike: KernelObject {
 
 impl_downcast!(sync FileLike);
 
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct FileDesc(i32);
 
 impl FileDesc {

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -18,7 +18,7 @@ rboot = { path = "../rboot", default-features = false }
 kernel-hal-bare = { path = "../kernel-hal-bare" }
 lazy_static = { version = "1.4", features = ["spin_no_std" ] }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "03bd9909" }
-trapframe = "0.1.7"
+trapframe = "0.2.0"
 executor = { git = "https://github.com/PanQL/executor.git", rev = "c86db90" }
 zircon-loader = { path = "../zircon-loader", default-features = false }
 zircon-object = { path = "../zircon-object" }

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 [features]
 graphic = []
 
+[profile.release]
+lto = true
+
 [dependencies]
 log = "0.4"
 spin = "0.5"

--- a/zircon-object/Cargo.toml
+++ b/zircon-object/Cargo.toml
@@ -14,6 +14,7 @@ elf = ["xmas-elf"]
 bitflags = "1.2"
 spin = "0.5"
 log = "0.4"
+hashbrown = "0.7"
 downcast-rs = { git = "https://github.com/rcore-os/downcast-rs" }
 kernel-hal = { path = "../kernel-hal" }
 numeric-enum-macro = "0.2"

--- a/zircon-object/src/ipc/channel.rs
+++ b/zircon-object/src/ipc/channel.rs
@@ -1,11 +1,12 @@
 use {
     crate::object::*,
-    alloc::collections::{BTreeMap, VecDeque},
+    alloc::collections::VecDeque,
     alloc::sync::{Arc, Weak},
     alloc::vec::Vec,
     core::convert::TryInto,
     core::sync::atomic::{AtomicU32, Ordering},
     futures::channel::oneshot::{self, Sender},
+    hashbrown::HashMap,
     spin::Mutex,
 };
 
@@ -15,7 +16,7 @@ pub struct Channel {
     _counter: CountHelper,
     peer: Weak<Channel>,
     recv_queue: Mutex<VecDeque<T>>,
-    call_reply: Mutex<BTreeMap<TxID, Sender<ZxResult<T>>>>,
+    call_reply: Mutex<HashMap<TxID, Sender<ZxResult<T>>>>,
     next_txid: AtomicU32,
 }
 

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -1,9 +1,10 @@
 use {
     super::{exception::*, job::Job, job_policy::*, thread::Thread, *},
     crate::{object::*, signal::Futex, vm::*},
-    alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec},
+    alloc::{boxed::Box, sync::Arc, vec::Vec},
     core::{any::Any, sync::atomic::AtomicI32},
     futures::channel::oneshot::{self, Receiver, Sender},
+    hashbrown::HashMap,
     spin::Mutex,
 };
 
@@ -74,8 +75,8 @@ define_count_helper!(Process);
 struct ProcessInner {
     status: Status,
     max_handle_id: u32,
-    handles: BTreeMap<HandleValue, (Handle, Vec<Sender<()>>)>,
-    futexes: BTreeMap<usize, Arc<Futex>>,
+    handles: HashMap<HandleValue, (Handle, Vec<Sender<()>>)>,
+    futexes: HashMap<usize, Arc<Futex>>,
     threads: Vec<Arc<Thread>>,
 
     // special info

--- a/zircon-object/src/task/thread.rs
+++ b/zircon-object/src/task/thread.rs
@@ -185,7 +185,6 @@ impl Thread {
             context.general.rdi = arg1;
             context.general.rsi = arg2;
             context.general.rflags |= 0x3202;
-            context.vector.fcw = 0x37f;
             inner.state = ThreadState::Running;
             self.base.signal_set(Signal::THREAD_RUNNING);
         }
@@ -204,7 +203,6 @@ impl Thread {
             let context = inner.context.as_mut().ok_or(ZxError::BAD_STATE)?;
             context.general = regs;
             context.general.rflags |= 0x3202;
-            context.vector.fcw = 0x37f;
             inner.state = ThreadState::Running;
             self.base.signal_set(Signal::THREAD_RUNNING);
         }


### PR DESCRIPTION
* Remove vector registers from user context.
  It saves time for kernel-user switching.
  The vector registers should be saved and restored on thread context switch.
  Currently we leave it alone and it will be fixed in the future.
* Getting the TSC frequency once and store it in a global variable.
  Getting frequency uses `cpuid` instruction, which is very slow in virtual machine.
  This fixes the performance regression caused by #31 .
* Replace all BTreeMap by HashMap (in hashbrown crate).
  This increases the overall performance in microbenchmarks of VMO(20%) and Channel(5%).

<details>
  <summary>Microbenchmarks Results</summary>


Case | Fuchsia | BTreeMap | HashMap | Hash vs BTree | Hash vs Fuchsia
-- | -- | -- | -- | -- | --
Channel/WriteEtcReadEtc/1024bytes/0handles | 1099 | 1267 | 1253 | -1.10% | 14.01%
Channel/WriteEtcReadEtc/1024bytes/0handles.write_etc | 554 | 630 | 637 | 1.11% | 14.98%
Channel/WriteEtcReadEtc/1024bytes/0handles.read_etc | 545 | 636 | 616 | -3.14% | 13.03%
Channel/WriteEtcReadEtc/1024bytes/1handles | 1368 | 1605 | 1456 | -9.28% | 6.43%
Channel/WriteEtcReadEtc/1024bytes/1handles.write_etc | 682 | 828 | 733 | -11.47% | 7.48%
Channel/WriteEtcReadEtc/1024bytes/1handles.read_etc | 687 | 776 | 723 | -6.83% | 5.24%
Channel/WriteEtcReadEtc/32768bytes/0handles | 3833 | 2870 | 2830 | -1.39% | -26.17%
Channel/WriteEtcReadEtc/32768bytes/0handles.write_etc | 2105 | 1387 | 1359 | -2.02% | -35.44%
Channel/WriteEtcReadEtc/32768bytes/0handles.read_etc | 1728 | 1483 | 1472 | -0.74% | -14.81%
Channel/WriteEtcReadEtc/32768bytes/1handles | 3769 | 3498 | 3043 | -13.01% | -19.26%
Channel/WriteEtcReadEtc/32768bytes/1handles.write_etc | 1938 | 1662 | 1483 | -10.77% | -23.48%
Channel/WriteEtcReadEtc/32768bytes/1handles.read_etc | 1830 | 1836 | 1559 | -15.09% | -14.81%
Channel/WriteEtcReadEtc/64bytes/0handles | 1075 | 1235 | 1193 | -3.40% | 10.98%
Channel/WriteEtcReadEtc/64bytes/0handles.write_etc | 552 | 623 | 607 | -2.57% | 9.96%
Channel/WriteEtcReadEtc/64bytes/0handles.read_etc | 523 | 612 | 586 | -4.25% | 12.05%
Channel/WriteEtcReadEtc/64bytes/1handles | 1368 | 1789 | 1464 | -18.17% | 7.02%
Channel/WriteEtcReadEtc/64bytes/1handles.write_etc | 685 | 884 | 740 | -16.29% | 8.03%
Channel/WriteEtcReadEtc/64bytes/1handles.read_etc | 682 | 905 | 723 | -20.11% | 6.01%
Channel/WriteEtcReadEtc/65536bytes/0handles | 6302 | 4458 | 4388 | -1.57% | -30.37%
Channel/WriteEtcReadEtc/65536bytes/0handles.write_etc | 3460 | 2129 | 2069 | -2.82% | -40.20%
Channel/WriteEtcReadEtc/65536bytes/0handles.read_etc | 2842 | 2329 | 2319 | -0.43% | -18.40%
Channel/WriteEtcReadEtc/65536bytes/1handles | 6036 | 4738 | 4641 | -2.05% | -23.11%
Channel/WriteEtcReadEtc/65536bytes/1handles.write_etc | 3085 | 2280 | 2226 | -2.37% | -27.84%
Channel/WriteEtcReadEtc/65536bytes/1handles.read_etc | 2950 | 2458 | 2415 | -1.75% | -18.14%
Channel/WriteRead/1024bytes/0handles | 1120 | 1262 | 1253 | -0.71% | 11.88%
Channel/WriteRead/1024bytes/0handles.write | 561 | 631 | 624 | -1.11% | 11.23%
Channel/WriteRead/1024bytes/0handles.read | 559 | 631 | 629 | -0.32% | 12.52%
Channel/WriteRead/1024bytes/1handles | 1299 | 1502 | 1401 | -6.72% | 7.85%
Channel/WriteRead/1024bytes/1handles.write | 654 | 767 | 710 | -7.43% | 8.56%
Channel/WriteRead/1024bytes/1handles.read | 645 | 735 | 691 | -5.99% | 7.13%
Channel/WriteRead/32768bytes/0handles | 3684 | 2897 | 2826 | -2.45% | -23.29%
Channel/WriteRead/32768bytes/0handles.write | 2024 | 1396 | 1351 | -3.22% | -33.25%
Channel/WriteRead/32768bytes/0handles.read | 1661 | 1500 | 1475 | -1.67% | -11.20%
Channel/WriteRead/32768bytes/1handles | 3709 | 3135 | 3008 | -4.05% | -18.90%
Channel/WriteRead/32768bytes/1handles.write | 1903 | 1527 | 1453 | -4.85% | -23.65%
Channel/WriteRead/32768bytes/1handles.read | 1805 | 1608 | 1555 | -3.30% | -13.85%
Channel/WriteRead/64bytes/0handles | 1048 | 1208 | 1198 | -0.83% | 14.31%
Channel/WriteRead/64bytes/0handles.write | 533 | 612 | 615 | 0.49% | 15.38%
Channel/WriteRead/64bytes/0handles.read | 516 | 595 | 583 | -2.02% | 12.98%
Channel/WriteRead/64bytes/1handles | 1161 | 1520 | 1438 | -5.39% | 23.86%
Channel/WriteRead/64bytes/1handles.write | 579 | 769 | 734 | -4.55% | 26.77%
Channel/WriteRead/64bytes/1handles.read | 582 | 751 | 705 | -6.13% | 21.13%
Channel/WriteRead/65536bytes/0handles | 6310 | 4438 | 4368 | -1.58% | -30.78%
Channel/WriteRead/65536bytes/0handles.write | 3458 | 2104 | 2060 | -2.09% | -40.43%
Channel/WriteRead/65536bytes/0handles.read | 2852 | 2334 | 2307 | -1.16% | -19.11%
Channel/WriteRead/65536bytes/1handles | 6078 | 4801 | 4519 | -5.87% | -25.65%
Channel/WriteRead/65536bytes/1handles.write | 3229 | 2302 | 2156 | -6.34% | -33.23%
Channel/WriteRead/65536bytes/1handles.read | 2849 | 2499 | 2363 | -5.44% | -17.06%


Case | Fuchsia | BTreeMap | HashMap | Hash vs BTree | Hash vs Fuchsia
-- | -- | -- | -- | -- | --
HandleCreate_Vmo.create | 852 | 618 | 627 | 1.46% | -26.41%
HandleCreate_Vmo.close | 827 | 609 | 634 | 4.11% | -23.34%
Vmo/Clone/128kbytes.clone | 1595 | 814 | 834 | 2.46% | -47.71%
Vmo/Clone/128kbytes.close | 1293 | 4249 | 2424 | -42.95% | 87.47%
Vmo/Clone/2048kbytes.clone | 1475 | 832 | 884 | 6.25% | -40.07%
Vmo/Clone/2048kbytes.close | 1232 | 83220 | 25102 | -69.84% | 1937.50%
Vmo/Clone/512kbytes.clone | 1394 | 860 | 814 | -5.35% | -41.61%
Vmo/Clone/512kbytes.close | 1150 | 16194 | 6649 | -58.94% | 478.17%
Vmo/Clone/ReadCloneAll/128kbytes | 10032 | 18554 | 16245 | -12.44% | 61.93%
Vmo/Clone/ReadCloneAll/128kbytes.clone | 1336 | 918 | 876 | -4.58% | -34.43%
Vmo/Clone/ReadCloneAll/128kbytes.read | 7550 | 13305 | 12779 | -3.95% | 69.26%
Vmo/Clone/ReadCloneAll/128kbytes.close | 1146 | 4330 | 2590 | -40.18% | 126.00%
Vmo/Clone/ReadCloneAll/2048kbytes | 129816 | 367772 | 281990 | -23.32% | 117.22%
Vmo/Clone/ReadCloneAll/2048kbytes.clone | 1351 | 1149 | 1247 | 8.53% | -7.70%
Vmo/Clone/ReadCloneAll/2048kbytes.read | 127073 | 278604 | 255828 | -8.18% | 101.32%
Vmo/Clone/ReadCloneAll/2048kbytes.close | 1392 | 88018 | 24915 | -71.69% | 1689.87%
Vmo/Clone/ReadCloneAll/512kbytes | 34346 | 77050 | 65224 | -15.35% | 89.90%
Vmo/Clone/ReadCloneAll/512kbytes.clone | 1372 | 856 | 843 | -1.52% | -38.56%
Vmo/Clone/ReadCloneAll/512kbytes.read | 31610 | 60118 | 57582 | -4.22% | 82.16%
Vmo/Clone/ReadCloneAll/512kbytes.close | 1364 | 16076 | 6799 | -57.71% | 398.46%
Vmo/Clone/ReadCloneSome/128kbytes | 4586 | 8410 | 6833 | -18.75% | 49.00%
Vmo/Clone/ReadCloneSome/128kbytes.clone | 1306 | 792 | 833 | 5.18% | -36.22%
Vmo/Clone/ReadCloneSome/128kbytes.read | 2223 | 3439 | 3467 | 0.81% | 55.96%
Vmo/Clone/ReadCloneSome/128kbytes.close | 1056 | 4179 | 2533 | -39.39% | 139.87%
Vmo/Clone/ReadCloneSome/2048kbytes | 36951 | 140993 | 76866 | -45.48% | 108.02%
Vmo/Clone/ReadCloneSome/2048kbytes.clone | 1342 | 828 | 857 | 3.50% | -36.14%
Vmo/Clone/ReadCloneSome/2048kbytes.read | 34457 | 55235 | 52575 | -4.82% | 52.58%
Vmo/Clone/ReadCloneSome/2048kbytes.close | 1152 | 84930 | 23434 | -72.41% | 1934.20%
Vmo/Clone/ReadCloneSome/512kbytes | 10741 | 30269 | 20985 | -30.67% | 95.37%
Vmo/Clone/ReadCloneSome/512kbytes.clone | 1307 | 797 | 828 | 3.89% | -36.65%
Vmo/Clone/ReadCloneSome/512kbytes.read | 8367 | 13760 | 13574 | -1.35% | 62.23%
Vmo/Clone/ReadCloneSome/512kbytes.close | 1067 | 15712 | 6582 | -58.11% | 516.87%
Vmo/Clone/ReadOrigAll/128kbytes | 9969 | 18193 | 16400 | -9.86% | 64.51%
Vmo/Clone/ReadOrigAll/128kbytes.clone | 1367 | 855 | 878 | 2.69% | -35.77%
Vmo/Clone/ReadOrigAll/128kbytes.read | 7473 | 13033 | 12963 | -0.54% | 73.46%
Vmo/Clone/ReadOrigAll/128kbytes.close | 1129 | 4305 | 2558 | -40.58% | 126.57%
Vmo/Clone/ReadOrigAll/2048kbytes | 128791 | 367778 | 281173 | -23.55% | 118.32%
Vmo/Clone/ReadOrigAll/2048kbytes.clone | 1379 | 1169 | 1265 | 8.21% | -8.27%
Vmo/Clone/ReadOrigAll/2048kbytes.read | 126011 | 278181 | 254932 | -8.36% | 102.31%
Vmo/Clone/ReadOrigAll/2048kbytes.close | 1401 | 88428 | 24977 | -71.75% | 1682.80%
Vmo/Clone/ReadOrigAll/512kbytes | 34317 | 76603 | 65101 | -15.02% | 89.70%
Vmo/Clone/ReadOrigAll/512kbytes.clone | 1367 | 867 | 836 | -3.58% | -38.84%
Vmo/Clone/ReadOrigAll/512kbytes.read | 31575 | 59706 | 57490 | -3.71% | 82.07%
Vmo/Clone/ReadOrigAll/512kbytes.close | 1375 | 16031 | 6775 | -57.74% | 392.73%
Vmo/Clone/ReadOrigSome/128kbytes | 4615 | 8686 | 6772 | -22.04% | 46.74%
Vmo/Clone/ReadOrigSome/128kbytes.clone | 1314 | 814 | 829 | 1.84% | -36.91%
Vmo/Clone/ReadOrigSome/128kbytes.read | 2238 | 3597 | 3485 | -3.11% | 55.72%
Vmo/Clone/ReadOrigSome/128kbytes.close | 1063 | 4275 | 2458 | -42.50% | 131.23%
Vmo/Clone/ReadOrigSome/2048kbytes | 36573 | 140510 | 78297 | -44.28% | 114.08%
Vmo/Clone/ReadOrigSome/2048kbytes.clone | 1305 | 828 | 850 | 2.66% | -34.87%
Vmo/Clone/ReadOrigSome/2048kbytes.read | 34083 | 55045 | 53873 | -2.13% | 58.06%
Vmo/Clone/ReadOrigSome/2048kbytes.close | 1186 | 84636 | 23573 | -72.15% | 1887.61%
Vmo/Clone/ReadOrigSome/512kbytes | 11249 | 30390 | 21082 | -30.63% | 87.41%
Vmo/Clone/ReadOrigSome/512kbytes.clone | 1295 | 840 | 817 | -2.74% | -36.91%
Vmo/Clone/ReadOrigSome/512kbytes.read | 8868 | 13782 | 13565 | -1.57% | 52.97%
Vmo/Clone/ReadOrigSome/512kbytes.close | 1086 | 15767 | 6700 | -57.51% | 516.94%
Vmo/Clone/WriteCloneAll/128kbytes | 23373 | 18536 | 16411 | -11.46% | -29.79%
Vmo/Clone/WriteCloneAll/128kbytes.clone | 1435 | 917 | 924 | 0.76% | -35.61%
Vmo/Clone/WriteCloneAll/128kbytes.write | 19798 | 15399 | 13794 | -10.42% | -30.33%
Vmo/Clone/WriteCloneAll/128kbytes.close | 2139 | 2220 | 1694 | -23.69% | -20.80%
Vmo/Clone/WriteCloneAll/2048kbytes | 3916443 | 354894 | 270562 | -23.76% | -93.09%
Vmo/Clone/WriteCloneAll/2048kbytes.clone | 1729 | 1176 | 1157 | -1.62% | -33.08%
Vmo/Clone/WriteCloneAll/2048kbytes.write | 3740093 | 332024 | 254561 | -23.33% | -93.19%
Vmo/Clone/WriteCloneAll/2048kbytes.close | 15906 | 21694 | 14844 | -31.58% | -6.68%
Vmo/Clone/WriteCloneAll/512kbytes | 85559 | 73672 | 61669 | -16.29% | -27.92%
Vmo/Clone/WriteCloneAll/512kbytes.clone | 1416 | 851 | 871 | 2.35% | -38.49%
Vmo/Clone/WriteCloneAll/512kbytes.write | 79566 | 67049 | 56697 | -15.44% | -28.74%
Vmo/Clone/WriteCloneAll/512kbytes.close | 4577 | 5772 | 4101 | -28.95% | -10.40%
Vmo/Clone/WriteCloneSome/128kbytes | 6435 | 8299 | 6572 | -20.81% | 2.13%
Vmo/Clone/WriteCloneSome/128kbytes.clone | 1287 | 843 | 822 | -2.49% | -36.13%
Vmo/Clone/WriteCloneSome/128kbytes.write | 3774 | 3532 | 3557 | 0.71% | -5.75%
Vmo/Clone/WriteCloneSome/128kbytes.close | 1374 | 3925 | 2193 | -44.13% | 59.61%
Vmo/Clone/WriteCloneSome/2048kbytes | 69305 | 137641 | 74879 | -45.60% | 8.04%
Vmo/Clone/WriteCloneSome/2048kbytes.clone | 1429 | 848 | 850 | 0.24% | -40.52%
Vmo/Clone/WriteCloneSome/2048kbytes.write | 62704 | 60809 | 54928 | -9.67% | -12.40%
Vmo/Clone/WriteCloneSome/2048kbytes.close | 5173 | 75984 | 19101 | -74.86% | 269.24%
Vmo/Clone/WriteCloneSome/512kbytes | 18492 | 30121 | 20048 | -33.44% | 8.41%
Vmo/Clone/WriteCloneSome/512kbytes.clone | 1317 | 815 | 793 | -2.70% | -39.79%
Vmo/Clone/WriteCloneSome/512kbytes.write | 15079 | 14752 | 13856 | -6.07% | -8.11%
Vmo/Clone/WriteCloneSome/512kbytes.close | 2096 | 14555 | 5399 | -62.91% | 157.59%
Vmo/Clone/WriteOrigAll/128kbytes | 24186 | 23116 | 19959 | -13.66% | -17.48%
Vmo/Clone/WriteOrigAll/128kbytes.clone | 1379 | 944 | 866 | -8.26% | -37.20%
Vmo/Clone/WriteOrigAll/128kbytes.write | 20353 | 19349 | 17072 | -11.77% | -16.12%
Vmo/Clone/WriteOrigAll/128kbytes.close | 2454 | 2822 | 2021 | -28.38% | -17.64%
Vmo/Clone/WriteOrigAll/2048kbytes | 4095883 | 516836 | 416495 | -19.41% | -89.83%
Vmo/Clone/WriteOrigAll/2048kbytes.clone | 1731 | 1307 | 1253 | -4.13% | -27.61%
Vmo/Clone/WriteOrigAll/2048kbytes.write | 3886813 | 476555 | 394192 | -17.28% | -89.86%
Vmo/Clone/WriteOrigAll/2048kbytes.close | 19175 | 38974 | 21051 | -45.99% | 9.78%
Vmo/Clone/WriteOrigAll/512kbytes | 90906 | 92352 | 74240 | -19.61% | -18.33%
Vmo/Clone/WriteOrigAll/512kbytes.clone | 1424 | 971 | 867 | -10.71% | -39.12%
Vmo/Clone/WriteOrigAll/512kbytes.write | 83786 | 82812 | 67976 | -17.92% | -18.87%
Vmo/Clone/WriteOrigAll/512kbytes.close | 5696 | 8569 | 5397 | -37.02% | -5.25%
Vmo/Clone/WriteOrigSome/128kbytes | 6472 | 10406 | 7074 | -32.02% | 9.30%
Vmo/Clone/WriteOrigSome/128kbytes.clone | 1271 | 885 | 823 | -7.01% | -35.25%
Vmo/Clone/WriteOrigSome/128kbytes.write | 3825 | 4290 | 3932 | -8.34% | 2.80%
Vmo/Clone/WriteOrigSome/128kbytes.close | 1377 | 5230 | 2319 | -55.66% | 68.41%
Vmo/Clone/WriteOrigSome/2048kbytes | 72596 | 180854 | 84531 | -53.26% | 16.44%
Vmo/Clone/WriteOrigSome/2048kbytes.clone | 1455 | 945 | 902 | -4.55% | -38.01%
Vmo/Clone/WriteOrigSome/2048kbytes.write | 65173 | 74887 | 60464 | -19.26% | -7.23%
Vmo/Clone/WriteOrigSome/2048kbytes.close | 5967 | 105022 | 23165 | -77.94% | 288.22%
Vmo/Clone/WriteOrigSome/512kbytes | 18857 | 39011 | 22965 | -41.13% | 21.79%
Vmo/Clone/WriteOrigSome/512kbytes.clone | 1346 | 881 | 830 | -5.79% | -38.34%
Vmo/Clone/WriteOrigSome/512kbytes.write | 15224 | 17285 | 15472 | -10.49% | 1.63%
Vmo/Clone/WriteOrigSome/512kbytes.close | 2287 | 20845 | 6663 | -68.04% | 191.34%
Vmo/CloneMap/128kbytes.map | 12608 | 4928 | 4679 | -5.05% | -62.89%
Vmo/CloneMap/128kbytes.clone | 1594 | 3911 | 3703 | -5.32% | 132.31%
Vmo/CloneMap/128kbytes.close | 1158 | 4239 | 2486 | -41.35% | 114.68%
Vmo/CloneMap/128kbytes.unmap | 2350 | 3199 | 3066 | -4.16% | 30.47%
Vmo/CloneMap/2048kbytes.map | 168446 | 81772 | 55210 | -32.48% | -67.22%
Vmo/CloneMap/2048kbytes.clone | 1727 | 36890 | 36908 | 0.05% | 2037.12%
Vmo/CloneMap/2048kbytes.close | 1162 | 87805 | 23798 | -72.90% | 1948.02%
Vmo/CloneMap/2048kbytes.unmap | 3715 | 35120 | 35485 | 1.04% | 855.18%
Vmo/CloneMap/512kbytes.map | 43974 | 17527 | 14902 | -14.98% | -66.11%
Vmo/CloneMap/512kbytes.clone | 1632 | 10451 | 10453 | 0.02% | 540.50%
Vmo/CloneMap/512kbytes.close | 1174 | 16242 | 6817 | -58.03% | 480.66%
Vmo/CloneMap/512kbytes.unmap | 2545 | 9499 | 9582 | 0.87% | 276.50%
Vmo/Read/128kbytes | 6605 | 12098 | 11595 | -4.16% | 75.55%
Vmo/Read/2048kbytes | 116730 | 256991 | 230751 | -10.21% | 97.68%
Vmo/Read/512kbytes | 28967 | 55759 | 52022 | -6.70% | 79.59%
Vmo/Write/128kbytes | 5610 | 10009 | 9394 | -6.14% | 67.45%
Vmo/Write/2048kbytes | 107626 | 214975 | 187399 | -12.83% | 74.12%
Vmo/Write/512kbytes | 26988 | 45337 | 41766 | -7.88% | 54.76%
VmoMap/Read/128kbytes | 60092 | 20415 | 20089 | -1.60% | -66.57%
VmoMap/Read/2048kbytes | 9104023 | 323722 | 300831 | -7.07% | -96.70%
VmoMap/Read/512kbytes | 2321911 | 80052 | 77405 | -3.31% | -96.67%
VmoMap/Read/Kernel/128kbytes | 51653 | 25711 | 24532 | -4.59% | -52.51%
VmoMap/Read/Kernel/2048kbytes | 7649363 | 484787 | 422970 | -12.75% | -94.47%
VmoMap/Read/Kernel/512kbytes | 1941181 | 103447 | 96699 | -6.52% | -95.02%
VmoMap/Write/128kbytes | 59669 | 18288 | 18042 | -1.35% | -69.76%
VmoMap/Write/2048kbytes | 8897544 | 297739 | 276903 | -7.00% | -96.89%
VmoMap/Write/512kbytes | 2306391 | 74801 | 71511 | -4.40% | -96.90%
VmoMap/Write/Kernel/128kbytes | 51260 | 24347 | 23958 | -1.60% | -53.26%
VmoMap/Write/Kernel/2048kbytes | 7357273 | 404771 | 382766 | -5.44% | -94.80%
VmoMap/Write/Kernel/512kbytes | 186350 | 99784 | 97046 | -2.74% | -47.92%
VmoMapRange/Read/128kbytes | 29871 | 20564 | 19734 | -4.04% | -33.94%
VmoMapRange/Read/2048kbytes | 3913832 | 321667 | 298668 | -7.15% | -92.37%
VmoMapRange/Read/512kbytes | 1038261 | 80070 | 76968 | -3.87% | -92.59%
VmoMapRange/Read/Kernel/128kbytes | 28944 | 25309 | 24659 | -2.57% | -14.80%
VmoMapRange/Read/Kernel/2048kbytes | 4018803 | 483149 | 423603 | -12.32% | -89.46%
VmoMapRange/Read/Kernel/512kbytes | 103420 | 103591 | 96177 | -7.16% | -7.00%
VmoMapRange/Write/128kbytes | 26870 | 18668 | 18248 | -2.25% | -32.09%
VmoMapRange/Write/2048kbytes | 3856962 | 296891 | 276594 | -6.84% | -92.83%
VmoMapRange/Write/512kbytes | 98324 | 74071 | 71228 | -3.84% | -27.56%
VmoMapRange/Write/Kernel/128kbytes | 27771 | 23658 | 23969 | 1.31% | -13.69%
VmoMapRange/Write/Kernel/2048kbytes | 3727972 | 405616 | 390326 | -3.77% | -89.53%
VmoMapRange/Write/Kernel/512kbytes | 96146 | 100635 | 97129 | -3.48% | 1.02%

</details>