### PR TITLE
Fixes to Futex that makes the FutexTest pass

### DIFF
--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -149,14 +149,15 @@ impl Futex {
         }
         // The FutexFuture will be dropped when the thread is no longer waiting
         // if we wake without be woken, remove myself from the waiter_queue
-        impl Drop for FutexFuture{
+        impl Drop for FutexFuture {
             fn drop(&mut self) {
                 let inner = self.waiter.inner.lock();
                 if !inner.woken {
-                    if let Some(thread) = &self.waiter.thread{
-                        let futex=thread.proc().get_futex(inner.futex.value);
-                        let queue=&mut futex.inner.lock().waiter_queue;
-                        if let Some(pos)=queue.iter().position(|x|Arc::ptr_eq(&x,&self.waiter)){
+                    if let Some(thread) = &self.waiter.thread {
+                        let futex = thread.proc().get_futex(inner.futex.value);
+                        let queue = &mut futex.inner.lock().waiter_queue;
+                        if let Some(pos) = queue.iter().position(|x| Arc::ptr_eq(&x, &self.waiter))
+                        {
                             // Nobody cares about the order of queue, so just remove faster
                             queue.swap_remove_back(pos);
                         }

--- a/zircon-syscall/src/futex.rs
+++ b/zircon-syscall/src/futex.rs
@@ -43,6 +43,9 @@ impl Syscall<'_> {
             "futex.requeue: value_ptr={:?}, wake_count={:#x}, current_value={:#x}, requeue_ptr={:?}, requeue_count={:#x}, new_requeue_owner={:?}",
             value_ptr, wake_count, current_value, requeue_ptr, requeue_count, new_requeue_owner
         );
+        if value_ptr.is_null() || value_ptr.as_ptr() as usize % 4 != 0 {
+            return Err(ZxError::INVALID_ARGS);
+        }
         let value = value_ptr.as_ref()?;
         let requeue = requeue_ptr.as_ref()?;
         if value_ptr.as_ptr() == requeue_ptr.as_ptr() {
@@ -68,6 +71,9 @@ impl Syscall<'_> {
 
     pub fn sys_futex_wake(&self, value_ptr: UserInPtr<AtomicI32>, count: u32) -> ZxResult {
         info!("futex.wake: value_ptr={:?}, count={:#x}", value_ptr, count);
+        if value_ptr.is_null() || value_ptr.as_ptr() as usize % 4 != 0 {
+            return Err(ZxError::INVALID_ARGS);
+        }
         let value = value_ptr.as_ref()?;
         let proc = self.thread.proc();
         let futex = proc.get_futex(value);
@@ -77,6 +83,9 @@ impl Syscall<'_> {
 
     pub fn sys_futex_wake_single_owner(&self, value_ptr: UserInPtr<AtomicI32>) -> ZxResult {
         info!("futex.wake_single_owner: value_ptr={:?}", value_ptr);
+        if value_ptr.is_null() || value_ptr.as_ptr() as usize % 4 != 0 {
+            return Err(ZxError::INVALID_ARGS);
+        }
         let value = value_ptr.as_ref()?;
         let proc = self.thread.proc();
         proc.get_futex(value).wake_single_owner();


### PR DESCRIPTION
This PR contains two fixes to the Futex
- `Waiter` should be removed from `waiter_queue` on the wait timeout, which fixes the `FutexTest.RequeueUnqueuedOnTimeout`
- Futex syscalls should check alignmet of value_ptr, which fixes the `FutexTest.MisalignedFutextAddr`

All current tests in `FutexTest` should pass after this PR. 