### PR TITLE
Call thread.start should check status of the process

### DIFF
--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -175,7 +175,7 @@ pub fn run_userboot(images: &Images<impl AsRef<[u8]>>, cmdline: &str) -> Arc<Pro
     let msg = MessagePacket { data, handles };
     kernel_channel.write(msg).unwrap();
 
-    proc.start(&thread, entry, sp, handle, 0, spawn)
+    proc.start(&thread, entry, sp, Some(handle), 0, spawn)
         .expect("failed to start main thread");
     proc
 }

--- a/zircon-object/src/task/thread.rs
+++ b/zircon-object/src/task/thread.rs
@@ -470,7 +470,7 @@ mod tests {
         // start a new thread
         let thread_ref_count = Arc::strong_count(&thread);
         let handle = Handle::new(proc.clone(), Rights::DEFAULT_PROCESS);
-        proc.start(&thread, entry, stack_top, handle.clone(), 2, spawn)
+        proc.start(&thread, entry, stack_top, Some(handle.clone()), 2, spawn)
             .expect("failed to start thread");
 
         // wait 100ms for the new thread to exit
@@ -485,13 +485,13 @@ mod tests {
 
         // start again should fail
         assert_eq!(
-            proc.start(&thread, entry, stack_top, handle.clone(), 2, spawn),
+            proc.start(&thread, entry, stack_top, Some(handle.clone()), 2, spawn),
             Err(ZxError::BAD_STATE)
         );
 
         // start another thread should fail
         assert_eq!(
-            proc.start(&thread1, entry, stack_top, handle.clone(), 2, spawn),
+            proc.start(&thread1, entry, stack_top, Some(handle.clone()), 2, spawn),
             Err(ZxError::BAD_STATE)
         );
     }


### PR DESCRIPTION
The `thread.start` syscall should fail when the process status is not `Running`. Also, the `proc.start` syscall should call `proc.start` instead of `thread.start`, which sets process status to `Running`.
After this PR, the `Threads.ThreadStartOnInitialThread` test should pass.