### PR TITLE
Avoid deadlock in VmObject and VmMapping

### DIFF
--- a/zircon-object/src/vm/vmo/mod.rs
+++ b/zircon-object/src/vm/vmo/mod.rs
@@ -50,8 +50,8 @@ pub trait VMObjectTrait: Sync + Send {
     /// Commit a page.
     fn commit_page(&self, page_idx: usize, flags: MMUFlags) -> ZxResult<PhysAddr>;
 
-    /// Commit pages by an external function f.
-    /// the vmo is internally locked before it calls fn,
+    /// Commit pages with an external function f.
+    /// the vmo is internally locked before it calls f,
     /// allowing `VmMapping` to avoid deadlock
     fn commit_pages_with(
         &self,

--- a/zircon-object/src/vm/vmo/mod.rs
+++ b/zircon-object/src/vm/vmo/mod.rs
@@ -50,6 +50,14 @@ pub trait VMObjectTrait: Sync + Send {
     /// Commit a page.
     fn commit_page(&self, page_idx: usize, flags: MMUFlags) -> ZxResult<PhysAddr>;
 
+    /// Commit pages by an external function f.
+    /// the vmo is internally locked before it calls fn,
+    /// allowing `VmMapping` to avoid deadlock
+    fn commit_pages_with(
+        &self,
+        f: &mut dyn FnMut(&mut dyn FnMut(usize, MMUFlags) -> ZxResult<PhysAddr>) -> ZxResult,
+    ) -> ZxResult;
+
     /// Commit allocating physical memory.
     fn commit(&self, offset: usize, len: usize) -> ZxResult;
 

--- a/zircon-object/src/vm/vmo/paged.rs
+++ b/zircon-object/src/vm/vmo/paged.rs
@@ -4,11 +4,12 @@ use {
     alloc::collections::VecDeque,
     alloc::sync::{Arc, Weak},
     alloc::vec::Vec,
+    core::cell::{Ref, RefCell, RefMut},
     core::ops::Range,
     core::sync::atomic::*,
     hashbrown::HashMap,
     kernel_hal::{frame_flush, PhysFrame, PAGE_SIZE},
-    spin::Mutex,
+    spin::{Mutex, MutexGuard},
 };
 
 enum VMOType {
@@ -55,8 +56,15 @@ impl VMOType {
 
 /// The main VM object type, holding a list of pages.
 pub struct VMObjectPaged {
-    inner: Mutex<VMObjectPagedInner>,
+    /// The lock that protected the `inner`
+    /// This lock is shared between objects in the same clone trees to avoid deadlock
+    lock: Arc<Mutex<()>>,
+    inner: RefCell<VMObjectPagedInner>,
 }
+
+/// We always lock the lock before access to the Refcell, so it is actually sync
+#[allow(unsafe_code)]
+unsafe impl Sync for VMObjectPaged {}
 
 type WeakRef = Weak<VMObjectPaged>;
 
@@ -150,95 +158,70 @@ impl Drop for PageState {
 impl VMObjectPaged {
     /// Create a new VMO backing on physical memory allocated in pages.
     pub fn new(id: KoID, pages: usize) -> Arc<Self> {
-        VMObjectPaged::wrap(VMObjectPagedInner {
-            user_id: id,
-            type_: VMOType::Origin,
-            parent: None,
-            parent_offset: 0usize,
-            parent_limit: 0usize,
-            size: pages * PAGE_SIZE,
-            frames: HashMap::new(),
-            mappings: Vec::new(),
-            cache_policy: CachePolicy::Cached,
-            contiguous: false,
-            self_ref: Default::default(),
-            pin_count: 0,
-        })
+        VMObjectPaged::wrap(
+            VMObjectPagedInner {
+                user_id: id,
+                type_: VMOType::Origin,
+                parent: None,
+                parent_offset: 0usize,
+                parent_limit: 0usize,
+                size: pages * PAGE_SIZE,
+                frames: HashMap::new(),
+                mappings: Vec::new(),
+                cache_policy: CachePolicy::Cached,
+                contiguous: false,
+                self_ref: Default::default(),
+                pin_count: 0,
+            },
+            None,
+        )
     }
 
     /// Internal: Wrap an inner struct to object.
-    fn wrap(inner: VMObjectPagedInner) -> Arc<Self> {
+    fn wrap(inner: VMObjectPagedInner, lock_ref: Option<Arc<Mutex<()>>>) -> Arc<Self> {
         let obj = Arc::new(VMObjectPaged {
-            inner: Mutex::new(inner),
+            lock: lock_ref.unwrap_or_else(|| Arc::new(Mutex::new(()))),
+            inner: RefCell::new(inner),
         });
-        obj.inner.lock().self_ref = Arc::downgrade(&obj);
+        obj.inner.borrow_mut().self_ref = Arc::downgrade(&obj);
         obj
     }
 
-    /// Helper function to split range into sub-ranges within pages.
-    ///
-    /// All covered pages will be committed implicitly.
-    ///
-    /// ```text
-    /// VMO range:
-    /// |----|----|----|----|----|
-    ///
-    /// buf:
-    ///            [====len====]
-    /// |--offset--|
-    ///
-    /// sub-ranges:
-    ///            [===]
-    ///                [====]
-    ///                     [==]
-    /// ```
-    ///
-    /// `f` is a function to process in-page ranges.
-    /// It takes 2 arguments:
-    /// * `paddr`: the start physical address of the in-page range.
-    /// * `buf_range`: the range in view of the input buffer.
-    fn for_each_page(
-        &self,
-        offset: usize,
-        buf_len: usize,
-        flags: MMUFlags,
-        mut f: impl FnMut(PhysAddr, Range<usize>),
-    ) -> ZxResult {
-        let iter = BlockIter {
-            begin: offset,
-            end: offset + buf_len,
-            block_size_log2: 12,
-        };
-        for block in iter {
-            let paddr = self.commit_page(block.block, flags)?;
-            let buf_range = block.origin_begin() - offset..block.origin_end() - offset;
-            f(paddr + block.begin, buf_range);
-        }
-        Ok(())
+    /// get the reference to inner by lock the shared lock
+    fn get_inner(&self) -> (MutexGuard<()>, Ref<VMObjectPagedInner>) {
+        (self.lock.lock(), self.inner.borrow())
+    }
+
+    /// get the mutable reference to inner by lock the shared lock
+    fn get_inner_mut(&self) -> (MutexGuard<()>, RefMut<VMObjectPagedInner>) {
+        (self.lock.lock(), self.inner.borrow_mut())
     }
 }
 
 impl VMObjectTrait for VMObjectPaged {
     fn read(&self, offset: usize, buf: &mut [u8]) -> ZxResult {
-        if self.cache_policy() != CachePolicy::Cached {
+        let (_guard, mut inner) = self.get_inner_mut();
+        if inner.cache_policy != CachePolicy::Cached {
             return Err(ZxError::BAD_STATE);
         }
-        self.for_each_page(offset, buf.len(), MMUFlags::READ, |paddr, buf_range| {
+        inner.for_each_page(offset, buf.len(), MMUFlags::READ, |paddr, buf_range| {
             kernel_hal::pmem_read(paddr, &mut buf[buf_range]);
         })
     }
 
     fn write(&self, offset: usize, buf: &[u8]) -> ZxResult {
-        if self.cache_policy() != CachePolicy::Cached {
+        let (_guard, mut inner) = self.get_inner_mut();
+        if inner.cache_policy != CachePolicy::Cached {
             return Err(ZxError::BAD_STATE);
         }
-        self.for_each_page(offset, buf.len(), MMUFlags::WRITE, |paddr, buf_range| {
+        inner.for_each_page(offset, buf.len(), MMUFlags::WRITE, |paddr, buf_range| {
             kernel_hal::pmem_write(paddr, &buf[buf_range]);
         })
     }
 
     fn zero(&self, offset: usize, len: usize) -> ZxResult {
-        if offset + len > self.inner.lock().size {
+        let (_guard, mut inner) = self.get_inner_mut();
+        if offset + len > inner.size {
             return Err(ZxError::OUT_OF_RANGE);
         }
         let iter = BlockIter {
@@ -249,27 +232,27 @@ impl VMObjectTrait for VMObjectPaged {
         let mut unwanted = VecDeque::new();
         for block in iter {
             //let paddr = self.commit_page(block.block, MMUFlags::READ)?;
-            if block.len() == PAGE_SIZE && !self.is_contiguous() {
-                let _ = self.commit_page(block.block, MMUFlags::WRITE)?;
+            if block.len() == PAGE_SIZE && !inner.is_contiguous() {
+                let _ = inner.commit_page(block.block, MMUFlags::WRITE)?;
                 unwanted.push_back(block.block);
-                self.inner.lock().frames.remove(&block.block);
-            } else if self.committed_pages_in_range(block.block, block.block + 1) != 0 {
+                inner.frames.remove(&block.block);
+            } else if inner.committed_pages_in_range(block.block, block.block + 1) != 0 {
                 // check whether this page is initialized, otherwise nothing should be done
-                let paddr = self.commit_page(block.block, MMUFlags::WRITE)?;
+                let paddr = inner.commit_page(block.block, MMUFlags::WRITE)?;
                 kernel_hal::frame_zero_in_range(paddr, block.begin, block.end);
             }
         }
-        self.inner.lock().release_unwanted_pages(unwanted);
+        inner.release_unwanted_pages(unwanted);
         Ok(())
     }
 
     fn len(&self) -> usize {
-        self.inner.lock().size
+        self.get_inner().1.size
     }
 
     fn set_len(&self, len: usize) -> ZxResult {
         assert!(page_aligned(len));
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         if inner.pin_count > 0 {
             return Err(ZxError::BAD_STATE);
         }
@@ -278,26 +261,21 @@ impl VMObjectTrait for VMObjectPaged {
     }
 
     fn commit_page(&self, page_idx: usize, flags: MMUFlags) -> ZxResult<PhysAddr> {
-        let ret = match self.commit_page_internal(page_idx, flags, &Weak::new())? {
-            CommitResult::Ref(paddr) => Ok(paddr),
-            _ => unreachable!(),
-        };
-        // force check conntiguous on each leaf node
-        assert!(self.check_contig());
-        ret
+        self.get_inner_mut().1.commit_page(page_idx, flags)
     }
 
     fn commit(&self, offset: usize, len: usize) -> ZxResult {
+        let (_guard, mut inner) = self.get_inner_mut();
         let start_page = offset / PAGE_SIZE;
         let pages = len / PAGE_SIZE;
         for i in 0..pages {
-            self.commit_page(start_page + i, MMUFlags::WRITE)?;
+            inner.commit_page(start_page + i, MMUFlags::WRITE)?;
         }
         Ok(())
     }
 
     fn decommit(&self, offset: usize, len: usize) -> ZxResult {
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         if inner.parent.is_some() {
             return Err(ZxError::NOT_SUPPORTED);
         }
@@ -317,28 +295,30 @@ impl VMObjectTrait for VMObjectPaged {
     ) -> ZxResult<Arc<dyn VMObjectTrait>> {
         assert!(page_aligned(offset));
         assert!(page_aligned(len));
-        let child = self.inner.lock().create_child(offset, len, user_id)?;
+        let (_guard, mut inner) = self.get_inner_mut();
+        let child = inner.create_child(offset, len, user_id, &self.lock)?;
         Ok(child)
     }
 
     fn append_mapping(&self, mapping: Weak<VmMapping>) {
-        self.inner.lock().mappings.push(mapping);
+        self.get_inner_mut().1.mappings.push(mapping);
     }
 
     fn remove_mapping(&self, mapping: Weak<VmMapping>) {
-        let mut inner = self.inner.lock();
-        inner
+        self.get_inner_mut()
+            .1
             .mappings
             .drain_filter(|x| x.strong_count() == 0 || Weak::ptr_eq(x, &mapping));
     }
 
     fn complete_info(&self, info: &mut VmoInfo) {
+        let (_guard, inner) = self.get_inner();
         info.flags |= VmoInfoFlags::TYPE_PAGED;
-        self.inner.lock().complete_info(info);
+        inner.complete_info(info);
     }
 
     fn cache_policy(&self) -> CachePolicy {
-        let inner = self.inner.lock();
+        let (_guard, inner) = self.get_inner();
         inner.cache_policy
     }
 
@@ -349,7 +329,7 @@ impl VMObjectTrait for VMObjectPaged {
         // 3) vmo has no mappings
         // 4) vmo has no children (TODO)
         // 5) vmo is not a child
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         if !inner.frames.is_empty() && inner.cache_policy != CachePolicy::Cached {
             return Err(ZxError::BAD_STATE);
         }
@@ -373,16 +353,16 @@ impl VMObjectTrait for VMObjectPaged {
     }
 
     fn committed_pages_in_range(&self, start_idx: usize, end_idx: usize) -> usize {
-        let inner = self.inner.lock();
+        let (_guard, inner) = self.get_inner();
         inner.committed_pages_in_range(start_idx, end_idx)
     }
 
     fn share_count(&self) -> usize {
-        self.inner.lock().mappings.len()
+        self.get_inner().1.mappings.len()
     }
 
     fn pin(&self, offset: usize, len: usize) -> ZxResult {
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         if offset + len >= inner.size {
             return Err(ZxError::OUT_OF_RANGE);
         }
@@ -405,7 +385,7 @@ impl VMObjectTrait for VMObjectPaged {
     }
 
     fn unpin(&self, offset: usize, len: usize) -> ZxResult {
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         if offset + len >= inner.size {
             return Err(ZxError::OUT_OF_RANGE);
         }
@@ -428,7 +408,7 @@ impl VMObjectTrait for VMObjectPaged {
     }
 
     fn is_contiguous(&self) -> bool {
-        self.inner.lock().is_contiguous()
+        self.get_inner().1.is_contiguous()
     }
 
     fn is_paged(&self) -> bool {
@@ -446,21 +426,93 @@ enum CommitResult {
 }
 
 impl VMObjectPaged {
+    /// Create a list of contiguous pages
+    pub fn create_contiguous(&self, size: usize, align_log2: usize) -> ZxResult {
+        assert!(page_aligned(size));
+        let size_page = pages(size);
+        let mut frames = PhysFrame::alloc_contiguous(size_page, align_log2 - PAGE_SIZE_LOG2);
+        if frames.is_empty() {
+            return Err(ZxError::NO_MEMORY);
+        }
+        let (_guard, mut inner) = self.get_inner_mut();
+        inner.contiguous = true;
+        for (i, f) in frames.drain(0..).enumerate() {
+            kernel_hal::frame_zero_in_range(f.addr(), 0, PAGE_SIZE);
+            let mut state = PageState::new(f);
+            state.pin_count += 1;
+            inner.frames.insert(i, state);
+        }
+        Ok(())
+    }
+}
+
+impl VMObjectPagedInner {
+    /// Helper function to split range into sub-ranges within pages.
+    ///
+    /// All covered pages will be committed implicitly.
+    ///
+    /// ```text
+    /// VMO range:
+    /// |----|----|----|----|----|
+    ///
+    /// buf:
+    ///            [====len====]
+    /// |--offset--|
+    ///
+    /// sub-ranges:
+    ///            [===]
+    ///                [====]
+    ///                     [==]
+    /// ```
+    ///
+    /// `f` is a function to process in-page ranges.
+    /// It takes 2 arguments:
+    /// * `paddr`: the start physical address of the in-page range.
+    /// * `buf_range`: the range in view of the input buffer.
+    fn for_each_page(
+        &mut self,
+        offset: usize,
+        buf_len: usize,
+        flags: MMUFlags,
+        mut f: impl FnMut(PhysAddr, Range<usize>),
+    ) -> ZxResult {
+        let iter = BlockIter {
+            begin: offset,
+            end: offset + buf_len,
+            block_size_log2: 12,
+        };
+        for block in iter {
+            let paddr = self.commit_page(block.block, flags)?;
+            let buf_range = block.origin_begin() - offset..block.origin_end() - offset;
+            f(paddr + block.begin, buf_range);
+        }
+        Ok(())
+    }
+
+    fn commit_page(&mut self, page_idx: usize, flags: MMUFlags) -> ZxResult<PhysAddr> {
+        let ret = match self.commit_page_internal(page_idx, flags, &Weak::new())? {
+            CommitResult::Ref(paddr) => Ok(paddr),
+            _ => unreachable!(),
+        };
+        // force check conntiguous on each leaf node
+        assert!(self.check_contig());
+        ret
+    }
+
     /// Commit a page recursively.
     fn commit_page_internal(
-        &self,
+        &mut self,
         page_idx: usize,
         flags: MMUFlags,
         child: &WeakRef,
     ) -> ZxResult<CommitResult> {
-        let mut inner = self.inner.lock();
         // special case
-        let no_parent = inner.parent.is_none();
-        let no_frame = !inner.frames.contains_key(&page_idx);
-        let out_of_range = if inner.type_.is_hidden() || inner.parent.is_none() {
-            page_idx >= inner.size / PAGE_SIZE
+        let no_parent = self.parent.is_none();
+        let no_frame = !self.frames.contains_key(&page_idx);
+        let out_of_range = if self.type_.is_hidden() || self.parent.is_none() {
+            page_idx >= self.size / PAGE_SIZE
         } else {
-            (inner.parent_offset + page_idx * PAGE_SIZE) >= inner.parent_limit
+            (self.parent_offset + page_idx * PAGE_SIZE) >= self.parent_limit
         };
         if no_frame {
             // if out_of_range
@@ -474,56 +526,60 @@ impl VMObjectPaged {
                 kernel_hal::frame_zero_in_range(target_frame.addr(), 0, PAGE_SIZE);
                 if out_of_range {
                     // can never be a hidden vmo
-                    assert!(!inner.type_.is_hidden());
+                    assert!(!self.type_.is_hidden());
                 }
-                if inner.type_.is_hidden() {
+                if self.type_.is_hidden() {
                     return Ok(CommitResult::NewPage(target_frame));
                 }
-                inner.frames.insert(page_idx, PageState::new(target_frame));
+                self.frames.insert(page_idx, PageState::new(target_frame));
             } else {
                 // recursively find a frame in parent
-                let parent = inner.parent.as_ref().unwrap();
-                let parent_idx = page_idx + inner.parent_offset / PAGE_SIZE;
-                match parent.commit_page_internal(parent_idx, flags, &inner.self_ref)? {
-                    CommitResult::NewPage(frame) if !inner.type_.is_hidden() => {
-                        inner.frames.insert(page_idx, PageState::new(frame));
+                let parent = self.parent.as_ref().unwrap();
+                let parent_idx = page_idx + self.parent_offset / PAGE_SIZE;
+                match parent.inner.borrow_mut().commit_page_internal(
+                    parent_idx,
+                    flags,
+                    &self.self_ref,
+                )? {
+                    CommitResult::NewPage(frame) if !self.type_.is_hidden() => {
+                        self.frames.insert(page_idx, PageState::new(frame));
                     }
                     CommitResult::CopyOnWrite(frame) => {
                         let mut new_frame = PageState::new(frame);
                         // Cloning a contiguous vmo: original frames are stored in hidden parent nodes.
                         // In order to make sure original vmo (now is a child of hidden parent)
                         // owns physically contiguous frames, swap the new frame with the original
-                        if inner.contiguous {
-                            let mut parent_inner = parent.inner.lock();
+                        if self.contiguous {
+                            let mut parent_inner = parent.inner.borrow_mut();
                             if let Some(par_frame) = parent_inner.frames.get_mut(&parent_idx) {
                                 par_frame.swap(&mut new_frame);
                             }
                         }
-                        inner.frames.insert(page_idx, new_frame);
+                        self.frames.insert(page_idx, new_frame);
                     }
                     r => return Ok(r),
                 }
             }
         }
         // now the page must hit on this VMO
-        let (child_tag, other_child) = inner.type_.get_tag_and_other(child);
-        if inner.type_.is_hidden() {
+        let (child_tag, other_child) = self.type_.get_tag_and_other(child);
+        if self.type_.is_hidden() {
             let arc_other = other_child.upgrade().unwrap();
-            let locked_other = arc_other.inner.lock();
+            let other_inner = arc_other.inner.borrow();
             let in_range = {
-                let start = locked_other.parent_offset / PAGE_SIZE;
-                let end = locked_other.parent_limit / PAGE_SIZE;
+                let start = other_inner.parent_offset / PAGE_SIZE;
+                let end = other_inner.parent_limit / PAGE_SIZE;
                 page_idx >= start && page_idx < end
             };
             if !in_range {
-                let frame = inner.frames.remove(&page_idx).unwrap().take();
+                let frame = self.frames.remove(&page_idx).unwrap().take();
                 return Ok(CommitResult::CopyOnWrite(frame));
             }
         }
-        let frame = inner.frames.get_mut(&page_idx).unwrap();
+        let frame = self.frames.get_mut(&page_idx).unwrap();
         if frame.tag.is_split() {
             // has split, take out
-            let target_frame = inner.frames.remove(&page_idx).unwrap().take();
+            let target_frame = self.frames.remove(&page_idx).unwrap().take();
             return Ok(CommitResult::CopyOnWrite(target_frame));
         } else if flags.contains(MMUFlags::WRITE) && child_tag.is_split() {
             // copy-on-write
@@ -536,135 +592,6 @@ impl VMObjectPaged {
         Ok(CommitResult::Ref(frame.frame.addr()))
     }
 
-    /// Replace a child of the hidden node.
-    /// `new_start` and `new_end` are in bytes
-    fn replace_child(
-        &self,
-        old: &WeakRef,
-        old_id: KoID,
-        new: WeakRef,
-        new_range: Option<(usize, usize)>,
-    ) {
-        let mut inner = self.inner.lock();
-        let (tag, other) = inner.type_.get_tag_and_other(old);
-        let arc_other_child = other.upgrade().unwrap();
-        let mut other_child = arc_other_child.inner.lock();
-        let mut unwanted = VecDeque::<usize>::new();
-        if let Some((new_start, new_end)) = new_range {
-            let other_start = other_child.parent_offset / PAGE_SIZE;
-            let other_end = other_child.parent_limit / PAGE_SIZE;
-            let start = new_start / PAGE_SIZE;
-            let end = new_end / PAGE_SIZE;
-            for i in 0..inner.size / PAGE_SIZE {
-                let not_in_range =
-                    !((start <= i && end > i) || (other_start <= i && other_end > i));
-                if not_in_range {
-                    // if not in this node's range
-                    if inner.frames.contains_key(&i) {
-                        // if the frame is in our, remove it
-                        assert!(inner.frames.remove(&i).is_some());
-                    } else {
-                        // or it is in our ancestor, tell them we do not need it.
-                        unwanted.push_back(i + inner.parent_offset / PAGE_SIZE);
-                    }
-                } else {
-                    // if in this node's range, check if it can be moved
-                    if let Some(frame) = inner.frames.get(&i) {
-                        if frame.tag.is_split() {
-                            let mut new_frame = inner.frames.remove(&i).unwrap();
-                            if inner.contiguous
-                                && !other_child.contiguous
-                                && new_frame.pin_count >= 1
-                            {
-                                new_frame.pin_count -= 1;
-                            }
-                            if new_frame.tag == tag && other_start <= i && other_end > i {
-                                new_frame.tag = PageStateTag::Owned;
-                                let new_key = i - other_child.parent_offset / PAGE_SIZE;
-                                other_child.frames.insert(new_key, new_frame);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        inner.release_unwanted_pages(unwanted);
-
-        if old_id == inner.user_id {
-            let mut option_parent = inner.parent.clone();
-            let mut child = inner.self_ref.clone();
-            let mut skip_user_id = old_id;
-            while let Some(parent) = option_parent {
-                let mut locked_parent = parent.inner.lock();
-                if locked_parent.user_id == old_id {
-                    let (_, other) = locked_parent.type_.get_tag_and_other(&child);
-                    let new_user_id = other.upgrade().unwrap().inner.lock().user_id;
-                    child = locked_parent.self_ref.clone();
-                    assert_ne!(new_user_id, skip_user_id);
-                    locked_parent.user_id = new_user_id;
-                    skip_user_id = new_user_id;
-                    option_parent = locked_parent.parent.clone();
-                } else {
-                    break;
-                }
-            }
-        }
-
-        inner.user_id = other_child.user_id;
-        match &mut inner.type_ {
-            VMOType::Hidden { left, right, .. } => {
-                if left.ptr_eq(old) {
-                    *left = new;
-                } else if right.ptr_eq(old) {
-                    *right = new;
-                } else {
-                    panic!();
-                }
-            }
-            _ => panic!(),
-        }
-    }
-
-    /// Create a list of contiguous pages
-    pub fn create_contiguous(&self, size: usize, align_log2: usize) -> ZxResult {
-        assert!(page_aligned(size));
-        let size_page = pages(size);
-        let mut frames = PhysFrame::alloc_contiguous(size_page, align_log2 - PAGE_SIZE_LOG2);
-        if frames.is_empty() {
-            return Err(ZxError::NO_MEMORY);
-        }
-        let mut inner = self.inner.lock();
-        inner.contiguous = true;
-        for (i, f) in frames.drain(0..).enumerate() {
-            kernel_hal::frame_zero_in_range(f.addr(), 0, PAGE_SIZE);
-            let mut state = PageState::new(f);
-            state.pin_count += 1;
-            inner.frames.insert(i, state);
-        }
-        Ok(())
-    }
-
-    /// Check whether it is not physically contiguous when it should be
-    fn check_contig(&self) -> bool {
-        let inner = self.inner.lock();
-        if !inner.contiguous {
-            return true;
-        }
-        let mut base = 0;
-        for (key, ps) in inner.frames.iter() {
-            let new_base = ps.frame.addr() - key * PAGE_SIZE;
-            if base == 0 || new_base == base {
-                base = new_base;
-            } else {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-impl VMObjectPagedInner {
     fn decommit(&mut self, page_idx: usize) {
         self.frames.remove(&page_idx);
     }
@@ -686,7 +613,7 @@ impl VMObjectPagedInner {
         if let VMOType::Hidden { left, right, .. } = &self.type_ {
             for child in &[left, right] {
                 let child = child.upgrade().unwrap();
-                child.inner.lock().range_change(start, end, op);
+                child.inner.borrow().range_change(start, end, op);
             }
         }
     }
@@ -716,8 +643,8 @@ impl VMObjectPagedInner {
             }
             let mut current = self.parent.clone();
             let mut current_idx = i + self.parent_offset / PAGE_SIZE;
-            while let Some(locked) = current {
-                let inner = locked.inner.lock();
+            while let Some(vmop) = current {
+                let inner = vmop.inner.borrow();
                 if let Some(frame) = inner.frames.get(&current_idx) {
                     if frame.tag.is_split() || inner.user_id == self.user_id {
                         count += 1;
@@ -753,7 +680,7 @@ impl VMObjectPagedInner {
         }
         let (tag, other_child) = self.type_.get_tag_and_other(child);
         let arc_child = other_child.upgrade().unwrap();
-        let mut child = arc_child.inner.lock();
+        let mut child = arc_child.inner.borrow_mut();
         let start = child.parent_offset / PAGE_SIZE;
         let end = child.parent_limit / PAGE_SIZE;
         // merge nodes to the child
@@ -773,7 +700,7 @@ impl VMObjectPagedInner {
         child.parent_offset += self.parent_offset;
         child.parent_limit += self.parent_offset;
         if let Some(parent) = &self.parent {
-            parent.replace_child(
+            parent.inner.borrow_mut().replace_child(
                 &self.self_ref,
                 self.user_id,
                 other_child,
@@ -789,46 +716,53 @@ impl VMObjectPagedInner {
         offset: usize,
         len: usize,
         user_id: KoID,
+        lock_ref: &Arc<Mutex<()>>,
     ) -> ZxResult<Arc<VMObjectPaged>> {
         if self.cache_policy != CachePolicy::Cached || self.pin_count != 0 {
             return Err(ZxError::BAD_STATE);
         }
         // create child VMO
-        let child = VMObjectPaged::wrap(VMObjectPagedInner {
-            user_id,
-            type_: VMOType::Snapshot,
-            parent: None, // set later
-            parent_offset: offset,
-            parent_limit: (offset + len).min(self.size),
-            size: len,
-            frames: HashMap::new(),
-            mappings: Vec::new(),
-            cache_policy: CachePolicy::Cached,
-            contiguous: false,
-            self_ref: Default::default(),
-            pin_count: 0,
-        });
-        // construct a hidden VMO as shared parent
-        let hidden = VMObjectPaged::wrap(VMObjectPagedInner {
-            user_id: self.user_id,
-            type_: VMOType::Hidden {
-                left: self.self_ref.clone(),
-                right: Arc::downgrade(&child),
+        let child = VMObjectPaged::wrap(
+            VMObjectPagedInner {
+                user_id,
+                type_: VMOType::Snapshot,
+                parent: None, // set later
+                parent_offset: offset,
+                parent_limit: (offset + len).min(self.size),
+                size: len,
+                frames: HashMap::new(),
+                mappings: Vec::new(),
+                cache_policy: CachePolicy::Cached,
+                contiguous: false,
+                self_ref: Default::default(),
+                pin_count: 0,
             },
-            parent: self.parent.clone(),
-            parent_offset: self.parent_offset,
-            parent_limit: self.parent_limit,
-            size: self.size,
-            frames: core::mem::take(&mut self.frames),
-            mappings: Vec::new(),
-            cache_policy: CachePolicy::Cached,
-            contiguous: self.contiguous,
-            self_ref: Default::default(),
-            pin_count: self.pin_count,
-        });
+            Some(lock_ref.clone()),
+        );
+        // construct a hidden VMO as shared parent
+        let hidden = VMObjectPaged::wrap(
+            VMObjectPagedInner {
+                user_id: self.user_id,
+                type_: VMOType::Hidden {
+                    left: self.self_ref.clone(),
+                    right: Arc::downgrade(&child),
+                },
+                parent: self.parent.clone(),
+                parent_offset: self.parent_offset,
+                parent_limit: self.parent_limit,
+                size: self.size,
+                frames: core::mem::take(&mut self.frames),
+                mappings: Vec::new(),
+                cache_policy: CachePolicy::Cached,
+                contiguous: self.contiguous,
+                self_ref: Default::default(),
+                pin_count: self.pin_count,
+            },
+            Some(lock_ref.clone()),
+        );
         // update parent's child
         if let Some(parent) = self.parent.take() {
-            if let VMOType::Hidden { left, right, .. } = &mut parent.inner.lock().type_ {
+            if let VMOType::Hidden { left, right, .. } = &mut parent.inner.borrow_mut().type_ {
                 if left.ptr_eq(&self.self_ref) {
                     *left = Arc::downgrade(&hidden);
                 } else if right.ptr_eq(&self.self_ref) {
@@ -842,7 +776,7 @@ impl VMObjectPagedInner {
         self.parent = Some(hidden.clone());
         self.parent_offset = 0;
         self.parent_limit = self.size;
-        child.inner.lock().parent = Some(hidden);
+        child.inner.borrow_mut().parent = Some(hidden);
         // update mappings
         for map in self.mappings.iter() {
             if let Some(map) = map.upgrade() {
@@ -850,6 +784,95 @@ impl VMObjectPagedInner {
             }
         }
         Ok(child)
+    }
+
+    /// Replace a child of the hidden node.
+    /// `new_start` and `new_end` are in bytes
+    fn replace_child(
+        &mut self,
+        old: &WeakRef,
+        old_id: KoID,
+        new: WeakRef,
+        new_range: Option<(usize, usize)>,
+    ) {
+        let (tag, other) = self.type_.get_tag_and_other(old);
+        let arc_other_child = other.upgrade().unwrap();
+        let mut other_child = arc_other_child.inner.borrow_mut();
+        let mut unwanted = VecDeque::<usize>::new();
+        if let Some((new_start, new_end)) = new_range {
+            let other_start = other_child.parent_offset / PAGE_SIZE;
+            let other_end = other_child.parent_limit / PAGE_SIZE;
+            let start = new_start / PAGE_SIZE;
+            let end = new_end / PAGE_SIZE;
+            for i in 0..self.size / PAGE_SIZE {
+                let not_in_range =
+                    !((start <= i && end > i) || (other_start <= i && other_end > i));
+                if not_in_range {
+                    // if not in this node's range
+                    if self.frames.contains_key(&i) {
+                        // if the frame is in our, remove it
+                        assert!(self.frames.remove(&i).is_some());
+                    } else {
+                        // or it is in our ancestor, tell them we do not need it.
+                        unwanted.push_back(i + self.parent_offset / PAGE_SIZE);
+                    }
+                } else {
+                    // if in this node's range, check if it can be moved
+                    if let Some(frame) = self.frames.get(&i) {
+                        if frame.tag.is_split() {
+                            let mut new_frame = self.frames.remove(&i).unwrap();
+                            if self.contiguous
+                                && !other_child.contiguous
+                                && new_frame.pin_count >= 1
+                            {
+                                new_frame.pin_count -= 1;
+                            }
+                            if new_frame.tag == tag && other_start <= i && other_end > i {
+                                new_frame.tag = PageStateTag::Owned;
+                                let new_key = i - other_child.parent_offset / PAGE_SIZE;
+                                other_child.frames.insert(new_key, new_frame);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.release_unwanted_pages(unwanted);
+
+        if old_id == self.user_id {
+            let mut option_parent = self.parent.clone();
+            let mut child = self.self_ref.clone();
+            let mut skip_user_id = old_id;
+            while let Some(parent) = option_parent {
+                let mut parent_inner = parent.inner.borrow_mut();
+                if parent_inner.user_id == old_id {
+                    let (_, other) = parent_inner.type_.get_tag_and_other(&child);
+                    let new_user_id = other.upgrade().unwrap().inner.borrow().user_id;
+                    child = parent_inner.self_ref.clone();
+                    assert_ne!(new_user_id, skip_user_id);
+                    parent_inner.user_id = new_user_id;
+                    skip_user_id = new_user_id;
+                    option_parent = parent_inner.parent.clone();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        self.user_id = other_child.user_id;
+        match &mut self.type_ {
+            VMOType::Hidden { left, right, .. } => {
+                if left.ptr_eq(old) {
+                    *left = new;
+                } else if right.ptr_eq(old) {
+                    *right = new;
+                } else {
+                    panic!();
+                }
+            }
+            _ => panic!(),
+        }
     }
 
     fn complete_info(&self, info: &mut VmoInfo) {
@@ -870,42 +893,42 @@ impl VMObjectPagedInner {
         let mut option_parent = self.parent.clone();
         let mut child = self.self_ref.clone();
         while let Some(parent) = option_parent {
-            let mut locked_parent = parent.inner.lock();
-            let (tag, other) = locked_parent.type_.get_tag_and_other(&child);
+            let mut parent_inner = parent.inner.borrow_mut();
+            let (tag, other) = parent_inner.type_.get_tag_and_other(&child);
             let arc_other = other.upgrade().unwrap();
-            let mut locked_other = arc_other.inner.lock();
-            let start = locked_other.parent_offset / PAGE_SIZE;
-            let end = locked_other.parent_limit / PAGE_SIZE;
+            let mut other_inner = arc_other.inner.borrow_mut();
+            let start = other_inner.parent_offset / PAGE_SIZE;
+            let end = other_inner.parent_limit / PAGE_SIZE;
             for _ in 0..unwanted.len() {
                 let idx = unwanted.pop_front().unwrap();
-                // if the frame is in locked_other's range, check if it can be move to locked_other
+                // if the frame is in other_inner's range, check if it can be move to other_inner
                 if start <= idx && idx < end {
-                    if locked_parent.frames.contains_key(&idx) {
-                        let mut to_insert = locked_parent.frames.remove(&idx).unwrap();
-                        if locked_parent.contiguous
-                            && !locked_other.contiguous
+                    if parent_inner.frames.contains_key(&idx) {
+                        let mut to_insert = parent_inner.frames.remove(&idx).unwrap();
+                        if parent_inner.contiguous
+                            && !other_inner.contiguous
                             && to_insert.pin_count >= 1
                         {
                             to_insert.pin_count -= 1;
                         }
                         if to_insert.tag != tag.negate() {
                             to_insert.tag = PageStateTag::Owned;
-                            locked_other.frames.insert(idx - start, to_insert);
+                            other_inner.frames.insert(idx - start, to_insert);
                         }
-                        unwanted.push_back(idx + locked_parent.parent_offset / PAGE_SIZE);
+                        unwanted.push_back(idx + parent_inner.parent_offset / PAGE_SIZE);
                     }
                 } else {
                     // otherwise, if it exists in our frames, remove it; if not, push_back it again
-                    if locked_parent.frames.contains_key(&idx) {
-                        locked_parent.frames.remove(&idx);
+                    if parent_inner.frames.contains_key(&idx) {
+                        parent_inner.frames.remove(&idx);
                     } else {
-                        unwanted.push_back(idx + locked_parent.parent_offset / PAGE_SIZE);
+                        unwanted.push_back(idx + parent_inner.parent_offset / PAGE_SIZE);
                     }
                 }
             }
-            child = locked_parent.self_ref.clone();
-            option_parent = locked_parent.parent.clone();
-            drop(locked_parent);
+            child = parent_inner.self_ref.clone();
+            option_parent = parent_inner.parent.clone();
+            drop(parent_inner);
         }
     }
 
@@ -913,7 +936,7 @@ impl VMObjectPagedInner {
         if new_size == 0 && new_size < self.size {
             self.frames.clear();
             if let Some(parent) = self.parent.as_ref() {
-                parent.inner.lock().remove_child(&self.self_ref);
+                parent.inner.borrow_mut().remove_child(&self.self_ref);
                 self.parent = None;
             }
         } else if new_size < self.size {
@@ -936,14 +959,31 @@ impl VMObjectPagedInner {
     fn clear_invalild_mappings(&mut self) {
         self.mappings.drain_filter(|x| x.strong_count() == 0);
     }
+
+    /// Check whether it is not physically contiguous when it should be
+    fn check_contig(&self) -> bool {
+        if !self.contiguous {
+            return true;
+        }
+        let mut base = 0;
+        for (key, ps) in self.frames.iter() {
+            let new_base = ps.frame.addr() - key * PAGE_SIZE;
+            if base == 0 || new_base == base {
+                base = new_base;
+            } else {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 impl Drop for VMObjectPaged {
     fn drop(&mut self) {
-        let mut inner = self.inner.lock();
+        let (_guard, mut inner) = self.get_inner_mut();
         // remove self from parent
         if let Some(parent) = &inner.parent {
-            parent.inner.lock().remove_child(&inner.self_ref);
+            parent.inner.borrow_mut().remove_child(&inner.self_ref);
         }
         let is_conti = inner.is_contiguous();
         for frame in inner.frames.iter_mut() {

--- a/zircon-object/src/vm/vmo/paged.rs
+++ b/zircon-object/src/vm/vmo/paged.rs
@@ -264,6 +264,14 @@ impl VMObjectTrait for VMObjectPaged {
         self.get_inner_mut().1.commit_page(page_idx, flags)
     }
 
+    fn commit_pages_with(
+        &self,
+        f: &mut dyn FnMut(&mut dyn FnMut(usize, MMUFlags) -> ZxResult<PhysAddr>) -> ZxResult,
+    ) -> ZxResult {
+        let (_guard, mut inner) = self.get_inner_mut();
+        f(&mut |page_idx, flags| inner.commit_page(page_idx, flags))
+    }
+
     fn commit(&self, offset: usize, len: usize) -> ZxResult {
         let (_guard, mut inner) = self.get_inner_mut();
         let start_page = offset / PAGE_SIZE;

--- a/zircon-object/src/vm/vmo/paged.rs
+++ b/zircon-object/src/vm/vmo/paged.rs
@@ -57,7 +57,7 @@ impl VMOType {
 /// The main VM object type, holding a list of pages.
 pub struct VMObjectPaged {
     /// The lock that protected the `inner`
-    /// This lock is shared between objects in the same clone trees to avoid deadlock
+    /// This lock is shared between objects in the same clone tree to avoid deadlock
     lock: Arc<Mutex<()>>,
     inner: RefCell<VMObjectPagedInner>,
 }

--- a/zircon-object/src/vm/vmo/physical.rs
+++ b/zircon-object/src/vm/vmo/physical.rs
@@ -68,6 +68,13 @@ impl VMObjectTrait for VMObjectPhysical {
         Ok(self.paddr + page_idx * PAGE_SIZE)
     }
 
+    fn commit_pages_with(
+        &self,
+        f: &mut dyn FnMut(&mut dyn FnMut(usize, MMUFlags) -> ZxResult<PhysAddr>) -> ZxResult,
+    ) -> ZxResult {
+        f(&mut |page_idx, _flags| Ok(self.paddr + page_idx * PAGE_SIZE))
+    }
+
     fn commit(&self, _offset: usize, _len: usize) -> ZxResult {
         // do nothing
         Ok(())

--- a/zircon-object/src/vm/vmo/slice.rs
+++ b/zircon-object/src/vm/vmo/slice.rs
@@ -54,6 +54,13 @@ impl VMObjectTrait for VMObjectSlice {
             .commit_page(page_idx + self.offset / PAGE_SIZE, flags)
     }
 
+    fn commit_pages_with(
+        &self,
+        f: &mut dyn FnMut(&mut dyn FnMut(usize, MMUFlags) -> ZxResult<PhysAddr>) -> ZxResult,
+    ) -> ZxResult {
+        self.parent.commit_pages_with(f)
+    }
+
     fn commit(&self, offset: usize, len: usize) -> ZxResult {
         self.parent.commit(offset + self.offset, len)
     }


### PR DESCRIPTION
Fixes #17
This PR avoid deadlocks in vm mod by:
- Share locks between `VMObjectPaged` that are in the same clone tree
- Lock `VMObjectPaged` before lock `VmMapping`, or release `VmMapping` before lock `VMObjectPaged`

However, run zircon directly with `kernel-hal-unix` still do not works, since it triggers a segmentation fault or (rarely) illegal instruction.