### PR TITLE
Fixes and workarounds about PCI on qemu

### DIFF
--- a/kernel-hal-bare/src/arch/x86_64/interrupt.rs
+++ b/kernel-hal-bare/src/arch/x86_64/interrupt.rs
@@ -174,7 +174,7 @@ pub fn irq_remove_handle(irq: u8) -> bool {
 }
 
 #[export_name = "hal_irq_allocate_block"]
-pub fn allocate_block(irq_num: u32) -> Option<usize> {
+pub fn allocate_block(irq_num: u32) -> Option<(usize, usize)> {
     let irq_num = u32::next_power_of_two(irq_num) as usize;
     let mut irq_start = 0x20;
     let mut irq_cur = irq_start;
@@ -184,13 +184,13 @@ pub fn allocate_block(irq_num: u32) -> Option<usize> {
             irq_cur += 1;
         } else {
             irq_start = (irq_cur & (irq_num - 1)) + irq_num;
-            irq_cur = irq_start
+            irq_cur = irq_start;
         }
     }
     for i in irq_start..irq_start + irq_num {
         table[i] = Some(Box::new(|| {}));
     }
-    Some(irq_start)
+    Some((irq_start, irq_num))
 }
 
 #[export_name = "hal_irq_free_block"]

--- a/kernel-hal-bare/src/arch/x86_64/interrupt.rs
+++ b/kernel-hal-bare/src/arch/x86_64/interrupt.rs
@@ -175,7 +175,7 @@ pub fn irq_remove_handle(irq: u8) -> bool {
 
 #[export_name = "hal_irq_allocate_block"]
 pub fn allocate_block(irq_num: u32) -> Option<(usize, usize)> {
-    info!("hal_irq_allocate_block: count={:#x?}",irq_num);
+    info!("hal_irq_allocate_block: count={:#x?}", irq_num);
     let irq_num = u32::next_power_of_two(irq_num) as usize;
     let mut irq_start = 0x20;
     let mut irq_cur = irq_start;
@@ -191,7 +191,10 @@ pub fn allocate_block(irq_num: u32) -> Option<(usize, usize)> {
     for i in irq_start..irq_start + irq_num {
         table[i] = Some(Box::new(|| {}));
     }
-    info!("hal_irq_allocate_block: start={:#x?} num={:#x?}",irq_start, irq_num);
+    info!(
+        "hal_irq_allocate_block: start={:#x?} num={:#x?}",
+        irq_start, irq_num
+    );
     Some((irq_start, irq_num))
 }
 

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -171,7 +171,7 @@ pub fn run_userboot(images: &Images<impl AsRef<[u8]>>, cmdline: &str) -> Arc<Pro
 
     // check: handle to root proc should be only
 
-    let data = Vec::from(cmdline.replace(':', "\0") + "\0console.shell=true\0");
+    let data = Vec::from(cmdline.replace(':', "\0") + "\0console.shell=true\0virtcon.disable=true\0");
     let msg = MessagePacket { data, handles };
     kernel_channel.write(msg).unwrap();
 

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -171,7 +171,8 @@ pub fn run_userboot(images: &Images<impl AsRef<[u8]>>, cmdline: &str) -> Arc<Pro
 
     // check: handle to root proc should be only
 
-    let data = Vec::from(cmdline.replace(':', "\0") + "\0console.shell=true\0virtcon.disable=true\0");
+    let data =
+        Vec::from(cmdline.replace(':', "\0") + "\0console.shell=true\0virtcon.disable=true\0");
     let msg = MessagePacket { data, handles };
     kernel_channel.write(msg).unwrap();
 
@@ -227,7 +228,12 @@ fn spawn(thread: Arc<Thread>) {
                     {
                         Ok(()) => {}
                         Err(e) => {
-                            error!("proc={:?} thread={:?} err={:?}", thread.proc().name(), thread.name(), e);
+                            error!(
+                                "proc={:?} thread={:?} err={:?}",
+                                thread.proc().name(),
+                                thread.name(),
+                                e
+                            );
                             panic!("Page Fault from user mode {:#x?}", cx);
                         }
                     }

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -227,7 +227,7 @@ fn spawn(thread: Arc<Thread>) {
                     {
                         Ok(()) => {}
                         Err(e) => {
-                            error!("{:?}", e);
+                            error!("proc={:?} thread={:?} err={:?}", thread.proc().name(), thread.name(), e);
                             panic!("Page Fault from user mode {:#x?}", cx);
                         }
                     }

--- a/zircon-object/src/dev/pci/bus.rs
+++ b/zircon-object/src/dev/pci/bus.rs
@@ -373,8 +373,8 @@ impl MmioPcieAddressProvider {
         if ecam.bus_start > ecam.bus_end {
             return Err(ZxError::INVALID_ARGS);
         }
-        let bus_count = ecam.bus_end + 1 - ecam.bus_start;
-        if ecam.size != bus_count as usize * PCIE_ECAM_BYTES_PER_BUS {
+        let bus_count = (ecam.bus_end - ecam.bus_start) as usize + 1;
+        if ecam.size != bus_count * PCIE_ECAM_BYTES_PER_BUS {
             return Err(ZxError::INVALID_ARGS);
         }
         let mut inner = self.ecam_regions.lock();

--- a/zircon-object/src/dev/pci/caps.rs
+++ b/zircon-object/src/dev/pci/caps.rs
@@ -82,10 +82,10 @@ pub struct PciCapacityMsi {
 impl PciCapacityMsi {
     pub fn create(cfg: &PciConfig, base: usize, id: u8) -> PciCapacityMsi {
         assert_eq!(id, 0x5); // PCIE_CAP_ID_MSI
-        let ctrl = cfg.read16_offset(base + 0x2);
+        let ctrl = cfg.read16_(base + 0x2);
         let has_pvm = (ctrl & 0x100) != 0;
         let is_64bit = (ctrl & 0x80) != 0;
-        cfg.write16_offset(base as usize + 0x2, ctrl & !0x71);
+        cfg.write16_(base + 0x2, ctrl & !0x71);
         let mask_bits = base + if is_64bit { 0x10 } else { 0xC };
         if has_pvm {
             cfg.write32_offset(mask_bits, 0xffff_ffff);
@@ -140,8 +140,8 @@ pub struct PciCapPcie {
 impl PciCapPcie {
     pub fn create(cfg: &PciConfig, base: u16, id: u8) -> PciCapPcie {
         assert_eq!(id, 0x10); // PCIE_CAP_ID_PCI_EXPRESS
-        let caps = cfg.read8_offset(base as usize + 0x2);
-        let device_caps = cfg.read32_offset(base as usize + 0x4);
+        let caps = cfg.read8_(base as usize + 0x2);
+        let device_caps = cfg.read32_(base as usize + 0x4);
         PciCapPcie {
             version: caps & 0xF,
             dev_type: PcieDeviceType::try_from(((caps >> 4) & 0xF) as u8).unwrap(),
@@ -159,7 +159,7 @@ pub struct PciCapAdvFeatures {
 impl PciCapAdvFeatures {
     pub fn create(cfg: &PciConfig, base: u16, id: u8) -> PciCapAdvFeatures {
         assert_eq!(id, 0x13); // PCIE_CAP_ID_ADVANCED_FEATURES
-        let caps = cfg.read8_offset(base as usize + 0x3);
+        let caps = cfg.read8_(base as usize + 0x3);
         PciCapAdvFeatures {
             has_flr: ((caps >> 1) & 0x1) != 0,
             has_tp: (caps & 0x1) != 0,

--- a/zircon-object/src/dev/pci/config.rs
+++ b/zircon-object/src/dev/pci/config.rs
@@ -1,5 +1,7 @@
 use super::*;
 use numeric_enum_macro::*;
+
+#[derive(Debug)]
 pub struct PciConfig {
     pub addr_space: PciAddrSpace,
     pub base: usize,
@@ -31,11 +33,20 @@ impl PciConfig {
     pub fn read8(&self, addr: PciReg8) -> u8 {
         self.read8_offset(self.base + addr as usize)
     }
+    pub fn read8_(&self, addr: usize) -> u8 {
+        self.read8_offset(self.base + addr)
+    }
     pub fn read16(&self, addr: PciReg16) -> u16 {
         self.read16_offset(self.base + addr as usize)
     }
+    pub fn read16_(&self, addr: usize) -> u16 {
+        self.read16_offset(self.base + addr)
+    }
     pub fn read32(&self, addr: PciReg32) -> u32 {
         self.read32_offset(self.base + addr as usize)
+    }
+    pub fn read32_(&self, addr: usize) -> u32 {
+        self.read32_offset(self.base + addr)
     }
     pub fn read_bar(&self, bar_: usize) -> u32 {
         self.read32_offset(self.base + PciReg32::BARBase as usize + bar_ * 4)
@@ -70,8 +81,14 @@ impl PciConfig {
     pub fn write16(&self, addr: PciReg16, val: u16) {
         self.write16_offset(self.base + addr as usize, val)
     }
+    pub fn write16_(&self, addr: usize, val: u16) {
+        self.write16_offset(self.base + addr, val)
+    }
     pub fn write32(&self, addr: PciReg32, val: u32) {
         self.write32_offset(self.base + addr as usize, val)
+    }
+    pub fn write32_(&self, addr: usize, val: u32) {
+        self.write32_offset(self.base + addr, val)
     }
     pub fn write_bar(&self, bar_: usize, val: u32) {
         self.write32_offset(self.base + PciReg32::BARBase as usize + bar_ * 4, val)

--- a/zircon-object/src/dev/pci/mod.rs
+++ b/zircon-object/src/dev/pci/mod.rs
@@ -16,6 +16,7 @@ pub enum PciAddrSpace {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct PciInitArgsAddrWindows {
     pub base: u64,
     pub size: usize,

--- a/zircon-object/src/dev/pci/nodes.rs
+++ b/zircon-object/src/dev/pci/nodes.rs
@@ -997,11 +997,11 @@ impl PcieDevice {
         let log2 = u32::next_power_of_two(irq_num).trailing_zeros();
         assert!(log2 <= 5);
         let cfg = self.cfg.as_ref().unwrap();
-        let (std, msi) = inner.msi().unwrap();
-        let data_reg = std.base as usize + PciCapacityMsi::addr_offset(msi.is_64bit);
-        let mut val = cfg.read32_(data_reg as usize);
-        val = (val & !0x70) | ((log2 & 0x7) << 4);
-        cfg.write32_(data_reg, val);
+        let (std, _msi) = inner.msi().unwrap();
+        let ctrl_addr = std.base as usize + PciCapacityMsi::ctrl_offset();
+        let mut val = cfg.read16_(ctrl_addr);
+        val = (val & !0x70) | ((log2 as u16 & 0x7) << 4);
+        cfg.write16_(ctrl_addr, val);
     }
     fn set_msi_enb(&self, inner: &MutexGuard<PcieDeviceInner>, enable: bool) {
         let cfg = self.cfg.as_ref().unwrap();

--- a/zircon-syscall/src/object.rs
+++ b/zircon-syscall/src/object.rs
@@ -240,6 +240,8 @@ impl Syscall<'_> {
                 }
                 let info = proc.get_handle_info(handle)?;
                 UserOutPtr::<HandleBasicInfo>::from(buffer).write(info)?;
+                actual.write_if_not_null(1)?;
+                avail.write_if_not_null(1)?;
             }
             Topic::Thread => {
                 if buffer_size < core::mem::size_of::<ThreadInfo>() {

--- a/zircon-syscall/src/pci.rs
+++ b/zircon-syscall/src/pci.rs
@@ -108,8 +108,8 @@ impl Syscall<'_> {
         // that collide with architectural registers.
         #[cfg(target_arch = "x86_64")]
         {
-            let num_buses: u8 = addr_win.bus_end - addr_win.bus_start + 1;
-            let mut end: u64 = addr_win.base + num_buses as u64 * PCIE_ECAM_BYTES_PER_BUS as u64;
+            let num_buses = (addr_win.bus_end - addr_win.bus_start) as u64 + 1;
+            let mut end: u64 = addr_win.base + num_buses * PCIE_ECAM_BYTES_PER_BUS as u64;
             let high_limit: u64 = 0xfec0_0000;
             if end > high_limit {
                 end = high_limit;


### PR DESCRIPTION
This PR include lots of bug fix to PCI, so it now works (partially) on qemu
- device tree outputted by `dm dump` list PCI devices correctly
- `lsblk` outputs the blocks in the AHCI disk correctly
- `gpt init` `gpt dump` `gpt add` `gpt edit` works, new partition is created, the `fuchsia-data` type is added successfully. (a kernal panic caused by user space page fault occurs after the `gpt edit`)
- `mkfs` with `minfs` completes without errors. However if we reboot the machine after that, the fshost will try to mount the filesystem on the disk as `minfs`, but it will fail since the magic bytes in the journal superblock is not correct.

We used commands from #53 for testing.

Also, the PR added proc name and thread name to the output when the kernal panic on a unhandled user exception. And as a workaround to a page fault caused by a message sent from virtual-console to sysmem driver, we disabled virtual-console in kernal cmdline.

The shell will be usable after this on debug version of zCore on qemu.