### PR TITLE
Implement Linux fork

### DIFF
--- a/linux-object/src/process.rs
+++ b/linux-object/src/process.rs
@@ -23,6 +23,7 @@ use zircon_object::{
 pub trait ProcessExt {
     fn create_linux(job: &Arc<Job>, rootfs: Arc<dyn FileSystem>) -> ZxResult<Arc<Self>>;
     fn linux(&self) -> &LinuxProcess;
+    fn fork_from(parent: &Arc<Self>) -> ZxResult<Arc<Self>>;
     fn vfork_from(parent: &Arc<Self>) -> ZxResult<Arc<Self>>;
 }
 
@@ -34,6 +35,40 @@ impl ProcessExt for Process {
 
     fn linux(&self) -> &LinuxProcess {
         self.ext().downcast_ref::<LinuxProcess>().unwrap()
+    }
+
+    /// [fork] the process.
+    ///
+    /// [fork]: http://man7.org/linux/man-pages/man2/fork.2.html
+    fn fork_from(parent: &Arc<Self>) -> ZxResult<Arc<Self>> {
+        let linux_parent = parent.linux();
+        let mut linux_parent_inner = linux_parent.inner.lock();
+        let new_linux_proc = LinuxProcess {
+            root_inode: linux_parent.root_inode.clone(),
+            parent: Arc::downgrade(parent),
+            inner: Mutex::new(LinuxProcessInner {
+                execute_path: linux_parent_inner.execute_path.clone(),
+                current_working_directory: linux_parent_inner.current_working_directory.clone(),
+                files: linux_parent_inner.files.clone(),
+                ..Default::default()
+            }),
+        };
+        let new_proc = Process::create_with_ext(&parent.job().create_child(0)?, "", new_linux_proc)?;
+        parent.vmar().clone_map(new_proc.vmar())?;
+
+        linux_parent_inner
+            .children
+            .insert(new_proc.id(), new_proc.clone());
+
+        // notify parent on terminated
+        let parent = parent.clone();
+        new_proc.add_signal_callback(Box::new(move |signal| {
+            if signal.contains(Signal::PROCESS_TERMINATED) {
+                parent.signal_set(Signal::SIGCHLD);
+            }
+            false
+        }));
+        Ok(new_proc)
     }
 
     /// [Vfork] the process.

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -218,7 +218,7 @@ impl Syscall<'_> {
             //            Sys::SELECT => self.sys_select(a0, a1.into(), a2.into(), a3.into(), a4.into()),
             Sys::DUP2 => self.sys_dup2(a0.into(), a1.into()),
             //            Sys::ALARM => self.unimplemented("alarm", Ok(0)),
-            Sys::FORK => self.sys_fork().await,
+            Sys::FORK => self.sys_fork(),
             Sys::VFORK => self.sys_vfork().await,
             Sys::RENAME => self.sys_rename(a0.into(), a1.into()),
             Sys::MKDIR => self.sys_mkdir(a0.into(), a1),

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -9,8 +9,15 @@ use linux_object::thread::ThreadExt;
 impl Syscall<'_> {
     /// Fork the current process. Return the child's PID.
     pub async fn sys_fork(&self) -> SysResult {
-        warn!("fork: not supported! go to vfork");
-        self.sys_vfork().await
+        info!("fork:");
+        let new_proc = Process::fork_from(self.zircon_process())?;
+        let new_thread = Thread::create_linux(&new_proc)?;
+        new_thread.start_with_regs(GeneralRegs::new_fork(self.regs), self.spawn_fn)?;
+
+        let new_proc: Arc<dyn KernelObject> = new_proc;
+        info!("fork: {} -> {}", self.zircon_process().id(), new_proc.id());
+        new_proc.wait_signal(Signal::SIGNALED).await; // wait for execve
+        Ok(new_proc.id() as usize)
     }
 
     pub async fn sys_vfork(&self) -> SysResult {

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -61,15 +61,7 @@ fn main(ramfs_data: &'static mut [u8], _cmdline: &str) {
     use alloc::vec;
     use linux_object::fs::MemBuf;
 
-    let args = [
-        "/bin/busybox",
-        "sh",
-        "-c",
-        "/bin/busybox ls && /bin/busybox cat",
-    ]
-    .iter()
-    .map(|&s| s.into())
-    .collect();
+    let args = vec!["/bin/busybox".into()];
     let envs = vec!["PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/x86_64-alpine-linux-musl/bin".into()];
 
     let device = Arc::new(MemBuf::new(ramfs_data));

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -61,10 +61,15 @@ fn main(ramfs_data: &'static mut [u8], _cmdline: &str) {
     use alloc::vec;
     use linux_object::fs::MemBuf;
 
-    let args = ["/bin/busybox", "sh", "-c", "/bin/busybox ls"]
-        .iter()
-        .map(|&s| s.into())
-        .collect();
+    let args = [
+        "/bin/busybox",
+        "sh",
+        "-c",
+        "/bin/busybox ls && /bin/busybox cat",
+    ]
+    .iter()
+    .map(|&s| s.into())
+    .collect();
     let envs = vec!["PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/x86_64-alpine-linux-musl/bin".into()];
 
     let device = Arc::new(MemBuf::new(ramfs_data));

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -61,7 +61,10 @@ fn main(ramfs_data: &'static mut [u8], _cmdline: &str) {
     use alloc::vec;
     use linux_object::fs::MemBuf;
 
-    let args = vec!["/bin/busybox".into()];
+    let args = ["/bin/busybox", "sh", "-c", "/bin/busybox ls"]
+        .iter()
+        .map(|&s| s.into())
+        .collect();
     let envs = vec!["PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/x86_64-alpine-linux-musl/bin".into()];
 
     let device = Arc::new(MemBuf::new(ramfs_data));


### PR DESCRIPTION
Add a method `vmar.fork_from` to allow a new VMAR cloning the entire address space and its VMOs from another one.

But it seems there are still bugs in VMAR and VMO with copy-on-write.
