### PR TITLE
Booting SMP on x86_64

### DIFF
--- a/kernel-hal-bare/Cargo.toml
+++ b/kernel-hal-bare/Cargo.toml
@@ -20,9 +20,10 @@ lazy_static = { version = "1.4", features = ["spin_no_std" ] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.11"
 uart_16550 = "0.2.6"
-raw-cpuid = "7.0"
+raw-cpuid = "8.0"
 pc-keyboard = "0.5"
 apic = { git = "https://github.com/rcore-os/apic-rs", rev = "fb86bd7" }
+x86-smpboot = { git = "https://github.com/rcore-os/x86-smpboot", rev = "257d695" }
 rcore-console = { git = "https://github.com/rcore-os/rcore-console", default-features = false, rev = "a980897b" }
 acpi = "1.0.0"
 

--- a/zCore/Makefile
+++ b/zCore/Makefile
@@ -4,6 +4,7 @@ zbi_file ?= bringup
 graphic ?=
 accel ?=
 linux ?=
+smp ?= 1
 test_filter ?= *.*
 
 build_args := -Z build-std=core,alloc --target $(arch).json
@@ -28,13 +29,13 @@ else
 endif
 
 qemu_opts := \
-	-smp cores=1
+	-smp $(smp)
 
 ifeq ($(arch), x86_64)
 qemu_opts += \
 	-machine q35 \
 	-cpu Haswell,+smap,-check,-fsgsbase \
-	-bios $(OVMF) \
+	-drive if=pflash,format=raw,readonly,file=$(OVMF) \
 	-drive format=raw,file=fat:rw:$(ESP) \
 	-drive format=qcow2,file=$(QEMU_DISK),id=disk,if=none \
 	-device ich9-ahci,id=ahci \
@@ -47,7 +48,7 @@ endif
 
 ifeq ($(accel), 1)
 ifeq ($(shell uname), Darwin)
-qemu_opts += -accel hax
+qemu_opts += -accel hvf
 else
 qemu_opts += -accel kvm -cpu host,migratable=no,+invtsc
 endif

--- a/zCore/src/logging.rs
+++ b/zCore/src/logging.rs
@@ -59,9 +59,10 @@ impl Log for SimpleLogger {
         let (tid, pid) = kernel_hal_bare::Thread::get_tid();
         print_in_color(
             format_args!(
-                "[{:?} {:>5} {}:{}] {}\n",
+                "[{:?} {:>5} {} {}:{}] {}\n",
                 kernel_hal_bare::timer_now(),
                 record.level(),
+                kernel_hal_bare::apic_local_id(),
                 pid,
                 tid,
                 record.args()

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -31,6 +31,7 @@ pub extern "C" fn _start(boot_info: &BootInfo) -> ! {
     kernel_hal_bare::init(kernel_hal_bare::Config {
         acpi_rsdp: boot_info.acpi2_rsdp_addr,
         smbios: boot_info.smbios_addr,
+        ap_fn: run,
     });
 
     let ramfs_data = unsafe {


### PR DESCRIPTION
## Changes
This PR adds x86_64 multi-core support to zCore.

The BSP starts up all application processors.
After booting into Rust code, the APs will initialize themselves and then run the executor.

## Testing
Since SMP brings trouble to multi-thread user programs, we will disable them by default.

To run zCore with multi-cores:
```
cd zCore && make run smp=4
```

You will see logs at INFO level like this:
```
[6436.095012605s  INFO 1 0:0] processor 1 started
[6436.11918813s  INFO 2 0:0] processor 2 started
[6436.143206418s  INFO 3 0:0] processor 3 started
```

## What's next
- Fix running user programs
- Implement IPI and flushing remote TLB
- Replace current single-thread executor with a more advanced one