### PR TITLE
Improve docs for `zircon_object::object`

### DIFF
--- a/zircon-object/src/object/handle.rs
+++ b/zircon-object/src/object/handle.rs
@@ -9,15 +9,19 @@ pub const INVALID_HANDLE: HandleValue = 0;
 /// A Handle is how a specific process refers to a specific kernel object.
 #[derive(Debug, Clone)]
 pub struct Handle {
+    /// The object referred to by the handle.
     pub object: Arc<dyn KernelObject>,
+    /// The handle's associated rights.
     pub rights: Rights,
 }
 
 impl Handle {
+    /// Create a new handle referring to the given object with given rights.
     pub fn new(object: Arc<dyn KernelObject>, rights: Rights) -> Self {
         Handle { object, rights }
     }
 
+    /// Get information about the provided handle and the object the handle refers to.
     pub fn get_info(&self) -> HandleBasicInfo {
         HandleBasicInfo {
             koid: self.object.id(),
@@ -33,6 +37,9 @@ impl Handle {
         }
     }
 
+    /// Get information about the handle itself.
+    ///
+    /// The returned `HandleInfo`'s `handle` field should set manually.
     pub fn get_handle_info(&self) -> HandleInfo {
         HandleInfo {
             obj_type: obj_type(&self.object),
@@ -42,6 +49,7 @@ impl Handle {
     }
 }
 
+/// Information about a handle and the object it refers to.
 #[repr(C)]
 #[derive(Default, Debug)]
 pub struct HandleBasicInfo {
@@ -53,6 +61,7 @@ pub struct HandleBasicInfo {
     padding: u32,
 }
 
+/// Get an object's type.
 pub fn obj_type(object: &Arc<dyn KernelObject>) -> u32 {
     match object.type_name() {
         "Process" => 1,
@@ -87,9 +96,11 @@ pub fn obj_type(object: &Arc<dyn KernelObject>) -> u32 {
     }
 }
 
+/// Information about a handle itself, including its `HandleValue`.
 #[repr(C)]
 #[derive(Default, Debug)]
 pub struct HandleInfo {
+    /// The handle's value in user space.
     pub handle: HandleValue,
     obj_type: u32,
     rights: u32,

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -120,23 +120,51 @@ mod signal;
 ///
 /// [`impl_kobject`]: impl_kobject
 pub trait KernelObject: DowncastSync + Debug {
+    /// Get object's KoID.
     fn id(&self) -> KoID;
+    /// Get the name of the type of the kernel object.
     fn type_name(&self) -> &str;
+    /// Get object's name.
     fn name(&self) -> alloc::string::String;
+    /// Set object's name.
     fn set_name(&self, name: &str);
+    /// Get the signal status.
     fn signal(&self) -> Signal;
+    /// Assert `signal`.
     fn signal_set(&self, signal: Signal);
+    /// Change signal status: first `clear` then `set` indicated bits.
+    ///
+    /// All signal callbacks will be called.
     fn signal_change(&self, clear: Signal, set: Signal);
+    /// Add `callback` for signal status changes.
+    ///
+    /// The `callback` is a function of `Fn(Signal) -> bool`.
+    /// It returns a bool indicating whether the handle process is over.
+    /// If true, the function will never be called again.
     fn add_signal_callback(&self, callback: SignalHandler);
+    /// Attempt to find a child of the object with given KoID.
+    ///
+    /// If the object is a *Process*, the *Threads* it contains may be obtained.
+    ///
+    /// If the object is a *Job*, its (immediate) child *Jobs* and the *Processes*
+    /// it contains may be obtained.
+    ///
+    /// If the object is a *Resource*, its (immediate) child *Resources* may be obtained.
     fn get_child(&self, _id: KoID) -> ZxResult<Arc<dyn KernelObject>> {
         Err(ZxError::WRONG_TYPE)
     }
+    /// Attempt to get the object's peer.
+    ///
+    /// An object peer is the opposite endpoint of a `Channel`, `Socket`, `Fifo`, or `EventPair`.
     fn peer(&self) -> ZxResult<Arc<dyn KernelObject>> {
         Err(ZxError::NOT_SUPPORTED)
     }
+    /// If the object is related to another (such as the other end of a channel, or the parent of
+    /// a job), returns the KoID of that object, otherwise returns zero.
     fn related_koid(&self) -> KoID {
         0
     }
+    /// Get object's allowed signals
     fn allowed_signals(&self) -> Signal {
         Signal::USER_ALL
     }

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Kernel object basis.
 //!
 //! # Create new kernel object
@@ -164,7 +165,7 @@ pub trait KernelObject: DowncastSync + Debug {
     fn related_koid(&self) -> KoID {
         0
     }
-    /// Get object's allowed signals
+    /// Get object's allowed signals.
     fn allowed_signals(&self) -> Signal {
         Signal::USER_ALL
     }
@@ -174,6 +175,7 @@ impl_downcast!(sync KernelObject);
 
 /// The base struct of a kernel object.
 pub struct KObjectBase {
+    /// The object's KoID.
     pub id: KoID,
     inner: Mutex<KObjectBaseInner>,
 }
@@ -511,6 +513,7 @@ pub struct DummyObject {
 impl_kobject!(DummyObject);
 
 impl DummyObject {
+    /// Create a new `DummyObject`.
     pub fn new() -> Arc<Self> {
         Arc::new(DummyObject {
             base: KObjectBase::new(),

--- a/zircon-object/src/object/rights.rs
+++ b/zircon-object/src/object/rights.rs
@@ -69,35 +69,85 @@ bitflags! {
         /// Allows suspending/resuming threads, etc.
         const MANAGE_THREAD = 1 << 18;
 
+        /// Not used.
         const APPLY_PROFILE = 1 << 19;
+
+        /// Used to duplicate a handle with the same rights.
         const SAME_RIGHTS = 1 << 31;
 
+
+        /// TRANSFER | DUPLICATE | WAIT | INSPECT
         const BASIC = Self::TRANSFER.bits | Self::DUPLICATE.bits | Self::WAIT.bits | Self::INSPECT.bits;
+
+        /// READ ｜ WRITE
         const IO = Self::READ.bits | Self::WRITE.bits;
+
+        /// GET_PROPERTY ｜ SET_PROPERTY
         const PROPERTY = Self::GET_PROPERTY.bits | Self::SET_PROPERTY.bits;
+
+        /// GET_POLICY ｜ SET_POLICY
         const POLICY = Self::GET_POLICY.bits | Self::SET_POLICY.bits;
 
+        /// BASIC & !Self::DUPLICATE | IO | SIGNAL | SIGNAL_PEER
         const DEFAULT_CHANNEL = Self::BASIC.bits & !Self::DUPLICATE.bits | Self::IO.bits | Self::SIGNAL.bits | Self::SIGNAL_PEER.bits;
+
+        /// BASIC | IO | PROPERTY | ENUMERATE | DESTROY | SIGNAL | MANAGE_PROCESS | MANAGE_THREAD
         const DEFAULT_PROCESS = Self::BASIC.bits | Self::IO.bits | Self::PROPERTY.bits | Self::ENUMERATE.bits | Self::DESTROY.bits
             | Self::SIGNAL.bits | Self::MANAGE_PROCESS.bits | Self::MANAGE_THREAD.bits;
+
+        /// BASIC | IO | PROPERTY | DESTROY | SIGNAL | MANAGE_THREAD
         const DEFAULT_THREAD = Self::BASIC.bits | Self::IO.bits | Self::PROPERTY.bits | Self::DESTROY.bits | Self::SIGNAL.bits | Self::MANAGE_THREAD.bits;
+
+        /// BASIC | IO | PROPERTY | MAP | SIGNAL
         const DEFAULT_VMO = Self::BASIC.bits | Self::IO.bits | Self::PROPERTY.bits | Self::MAP.bits | Self::SIGNAL.bits;
+
+        /// BASIC | WAIT
         const DEFAULT_VMAR = Self::BASIC.bits & !Self::WAIT.bits;
+
+        /// BASIC | IO | PROPERTY | POLICY | ENUMERATE | DESTROY | SIGNAL | MANAGE_JOB | MANAGE_PROCESS | MANAGE_THREAD
         const DEFAULT_JOB = Self::BASIC.bits | Self::IO.bits | Self::PROPERTY.bits | Self::POLICY.bits | Self::ENUMERATE.bits
             | Self::DESTROY.bits | Self::SIGNAL.bits | Self::MANAGE_JOB.bits | Self::MANAGE_PROCESS.bits | Self::MANAGE_THREAD.bits;
+
+        /// TRANSFER | DUPLICATE | WRITE | INSPECT
         const DEFAULT_RESOURCE = Self::TRANSFER.bits | Self::DUPLICATE.bits | Self::WRITE.bits | Self::INSPECT.bits;
+
+        /// BASIC | WRITE | SIGNAL
         const DEFAULT_DEBUGLOG = Self::BASIC.bits | Self::WRITE.bits | Self::SIGNAL.bits;
+
+        /// TRANSFER | INSPECT
         const DEFAULT_SUSPEND_TOKEN = Self::TRANSFER.bits | Self::INSPECT.bits;
+
+        /// (BASIC & !WAIT) | IO
         const DEFAULT_PORT = (Self::BASIC.bits & !Self::WAIT.bits) | Self::IO.bits;
+
+        /// BASIC | WRITE | SIGNAL
         const DEFAULT_TIMER = Self::BASIC.bits | Self::WRITE.bits | Self::SIGNAL.bits;
+
+        /// BASIC | SIGNAL
         const DEFAULT_EVENT = Self::BASIC.bits | Self::SIGNAL.bits;
+
+        /// BASIC | SIGNAL ｜ SIGNAL_PEER
         const DEFAULT_EVENTPAIR = Self::BASIC.bits | Self::SIGNAL.bits | Self::SIGNAL_PEER.bits;
+
+        /// BASIC | IO | SIGNAL | SIGNAL_PEER
         const DEFAULT_FIFO = Self::BASIC.bits | Self::IO.bits | Self::SIGNAL.bits | Self::SIGNAL_PEER.bits;
+
+        /// BASIC | IO | PROPERTY | SIGNAL | SIGNAL_PEER
         const DEFAULT_SOCKET = Self::BASIC.bits | Self::IO.bits | Self::PROPERTY.bits | Self::SIGNAL.bits | Self::SIGNAL_PEER.bits;
+
+        /// BASIC | PROPERTY | SIGNAL
         const DEFAULT_STREAM = Self::BASIC.bits | Self::PROPERTY.bits | Self::SIGNAL.bits;
+
+        /// (BASIC & !WAIT) | IO | MAP
         const DEFAULT_BTI = (Self::BASIC.bits & !Self::WAIT.bits) | Self::IO.bits | Self::MAP.bits;
+
+        /// BASIC | IO | SIGNAL
         const DEFAULT_INTERRUPT = Self::BASIC.bits | Self::IO.bits | Self::SIGNAL.bits;
+
+        /// BASIC | IO
         const DEFAULT_DEVICE = Self::BASIC.bits | Self::IO.bits;
+
+        /// BASIC | IO | SIGNAL
         const DEFAULT_PCI_INTERRUPT = Self::BASIC.bits | Self::IO.bits | Self::SIGNAL.bits;
     }
 }

--- a/zircon-object/src/object/signal.rs
+++ b/zircon-object/src/object/signal.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use {super::*, bitflags::bitflags};
 
 bitflags! {
@@ -58,6 +59,7 @@ bitflags! {
 }
 
 impl Signal {
+    /// Verify whether `number` only sets the bits specified in `allowed_signals`.
     pub fn verify_user_signal(allowed_signals: Signal, number: u32) -> ZxResult<Signal> {
         if (number & !allowed_signals.bits()) != 0 {
             Err(ZxError::INVALID_ARGS)


### PR DESCRIPTION
- `zircon_object::object` passes `#![deny(missing_docs)]`.

- But `#![allow(missing_docs)]` is added in `zircon_object::object::signal`. I think signals are named with their meanings, so no docs is okay.