### PR TITLE
pass all core-tests about socket

### DIFF
--- a/zircon-object/src/vm/vmar.rs
+++ b/zircon-object/src/vm/vmar.rs
@@ -499,6 +499,13 @@ impl VmAddressRegion {
         task_stats
     }
 
+    pub fn check_rights(&self, vaddr: usize, flags: MMUFlags) -> bool {
+        match self.find_mapping(vaddr) {
+            Some(map) => map.flags.contains(flags),
+            None => false,
+        }
+    }
+
     /// Read from address space.
     ///
     /// Return the actual number of bytes read.

--- a/zircon-syscall/src/vmar.rs
+++ b/zircon-syscall/src/vmar.rs
@@ -94,12 +94,12 @@ impl Syscall<'_> {
         if !vmo_rights.contains(Rights::MAP) {
             return Err(ZxError::ACCESS_DENIED);
         };
-        if !options.contains(VmOptions::PERM_READ)
-            && (!options.contains(VmOptions::PERM_WRITE)
-                || options.contains(VmOptions::PERM_EXECUTE))
-        {
-            return Err(ZxError::INVALID_ARGS);
-        }
+        // if !options.contains(VmOptions::PERM_READ)
+        //     && (!options.contains(VmOptions::PERM_WRITE)
+        //         || options.contains(VmOptions::PERM_EXECUTE))
+        // {
+        //     return Err(ZxError::INVALID_ARGS);
+        // }
         if options.contains(VmOptions::CAN_MAP_RXW) {
             return Err(ZxError::INVALID_ARGS);
         }
@@ -115,15 +115,15 @@ impl Syscall<'_> {
         let mut mapping_flags = MMUFlags::USER;
         mapping_flags.set(
             MMUFlags::READ,
-            vmar_rights.contains(Rights::READ) && vmo_rights.contains(Rights::READ),
+            vmar_rights.contains(Rights::READ) && vmo_rights.contains(Rights::READ) && options.contains(VmOptions::PERM_READ),
         );
         mapping_flags.set(
             MMUFlags::WRITE,
-            vmar_rights.contains(Rights::WRITE) && vmo_rights.contains(Rights::WRITE),
+            vmar_rights.contains(Rights::WRITE) && vmo_rights.contains(Rights::WRITE) && options.contains(VmOptions::PERM_WRITE),
         );
         mapping_flags.set(
             MMUFlags::EXECUTE,
-            vmar_rights.contains(Rights::EXECUTE) && vmo_rights.contains(Rights::EXECUTE),
+            vmar_rights.contains(Rights::EXECUTE) && vmo_rights.contains(Rights::EXECUTE) && options.contains(VmOptions::PERM_EXECUTE),
         );
         info!(
             "mmuflags: {:?}, is_specific {:?}",


### PR DESCRIPTION
Add right checks in socket and pass the rest core-tests (ReadIntoBadBuffer、WriteFromBadBuffer). 
But there is some doubts about my change in zircon-syscall::vmar::sys_vmar_map.

```rust
// if !options.contains(VmOptions::PERM_READ)
//     && (!options.contains(VmOptions::PERM_WRITE)
//         || options.contains(VmOptions::PERM_EXECUTE))
// {
//     return Err(ZxError::INVALID_ARGS);
// }
```
I comment these codes which make sense because in core-tests of socket, an address is mapped as not readable, not writable and not executable, which should be ok but leads to errors due to the code above. However, a page with no rights is useless and  only occurs in tests.
```rust
mapping_flags.set(
    MMUFlags::READ,
//  vmar_rights.contains(Rights::READ) && vmo_rights.contains(Rights::READ),
    vmar_rights.contains(Rights::READ) && vmo_rights.contains(Rights::READ) && options.contains(VmOptions::PERM_READ),
);
mapping_flags.set(
    MMUFlags::WRITE,
//  vmar_rights.contains(Rights::WRITE) && vmo_rights.contains(Rights::WRITE),
    vmar_rights.contains(Rights::WRITE) && vmo_rights.contains(Rights::WRITE) && options.contains(VmOptions::PERM_WRITE),
);
mapping_flags.set(
    MMUFlags::EXECUTE,
//  vmar_rights.contains(Rights::EXECUTE) && vmo_rights.contains(Rights::EXECUTE),
    vmar_rights.contains(Rights::EXECUTE) && vmo_rights.contains(Rights::EXECUTE) && options.contains(VmOptions::PERM_EXECUTE),
);
```
The implementation in zircon is same as zCore which doesn't care options and perm_xxxx. I am clear about the meanings of options::perm_xxxx, but without them, the rest core-tests will fail. (QAQ 
:sweat::sweat::sweat::sweat:

