### PR TITLE
Add some trivial tests to improve the coverage of `zircon_object::object`

### DIFF
--- a/zircon-object/src/object/handle.rs
+++ b/zircon-object/src/object/handle.rs
@@ -106,3 +106,35 @@ pub struct HandleInfo {
     rights: u32,
     unused: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "unknown type")]
+    fn test_ojb_type_unknown() {
+        let obj: Arc<dyn KernelObject> = DummyObject::new();
+        assert_eq!(1, obj_type(&obj));
+    }
+
+    #[test]
+    fn test_get_info() {
+        let obj = crate::task::Job::root();
+        let handle1 = Handle::new(obj.clone(), Rights::DEFAULT_JOB);
+        let info1 = handle1.get_info();
+        assert_eq!(info1.obj_type, 17);
+        assert_eq!(info1.props, 1);
+
+        let handle_info = handle1.get_handle_info();
+        assert_eq!(handle_info.obj_type, 17);
+
+        let handle2 = Handle::new(obj, Rights::READ);
+        let info2 = handle2.get_info();
+        assert_eq!(info2.props, 0);
+
+        // Let struct lines counted covered.
+        // See https://github.com/mozilla/grcov/issues/450
+        let _ = HandleBasicInfo::default();
+    }
+}

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -133,6 +133,8 @@ pub trait KernelObject: DowncastSync + Debug {
     fn signal(&self) -> Signal;
     /// Assert `signal`.
     fn signal_set(&self, signal: Signal);
+    /// Deassert `signal`.
+    fn signal_clear(&self, signal: Signal);
     /// Change signal status: first `clear` then `set` indicated bits.
     ///
     /// All signal callbacks will be called.
@@ -444,6 +446,9 @@ macro_rules! impl_kobject {
             }
             fn signal_set(&self, signal: Signal) {
                 self.base.signal_set(signal);
+            }
+            fn signal_clear(&self, signal: Signal) {
+                self.base.signal_clear(signal);
             }
             fn signal_change(&self, clear: Signal, set: Signal) {
                 self.base.signal_change(clear, set);

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -532,13 +532,13 @@ mod tests {
             async move {
                 flag.store(1, Ordering::SeqCst);
                 // Assert an irrelevant signal to test the `false` branch of the callback for `READABLE`.
-                object.base.signal_set(Signal::USER_SIGNAL_0);
-                object.base.signal_clear(Signal::USER_SIGNAL_0);
-                object.base.signal_set(Signal::READABLE);
+                object.signal_set(Signal::USER_SIGNAL_0);
+                object.signal_clear(Signal::USER_SIGNAL_0);
+                object.signal_set(Signal::READABLE);
                 async_std::task::sleep(Duration::from_millis(10)).await;
 
                 flag.store(2, Ordering::SeqCst);
-                object.base.signal_set(Signal::WRITABLE);
+                object.signal_set(Signal::WRITABLE);
             }
         });
         let object: Arc<dyn KernelObject> = object;
@@ -563,11 +563,11 @@ mod tests {
             let flag = flag.clone();
             async move {
                 flag.store(1, Ordering::SeqCst);
-                objs[0].base.signal_set(Signal::READABLE);
+                objs[0].signal_set(Signal::READABLE);
                 async_std::task::sleep(Duration::from_millis(10)).await;
 
                 flag.store(2, Ordering::SeqCst);
-                objs[1].base.signal_set(Signal::WRITABLE);
+                objs[1].signal_set(Signal::WRITABLE);
             }
         });
         let obj0: Arc<dyn KernelObject> = objs[0].clone();

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -205,24 +205,12 @@ impl KObjectBase {
 
     /// Create a kernel object base with initial `signal`.
     pub fn with_signal(signal: Signal) -> Self {
-        KObjectBase {
-            id: Self::new_koid(),
-            inner: Mutex::new(KObjectBaseInner {
-                signal,
-                ..Default::default()
-            }),
-        }
+        KObjectBase::with(Default::default(), signal)
     }
 
     /// Create a kernel object base with `name`.
     pub fn with_name(name: &str) -> Self {
-        KObjectBase {
-            id: Self::new_koid(),
-            inner: Mutex::new(KObjectBaseInner {
-                name: String::from(name),
-                ..Default::default()
-            }),
-        }
+        KObjectBase::with(name, Default::default())
     }
 
     /// Create a kernel object base with both signal and name

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -594,4 +594,26 @@ mod tests {
         assert_eq!(signals, [Signal::READABLE, Signal::WRITABLE]);
         assert_eq!(flag.load(Ordering::SeqCst), 2);
     }
+
+    #[test]
+    fn test_trait_with_dummy() {
+        let dummy = DummyObject::new();
+        assert_eq!(dummy.name(), String::from(""));
+        dummy.set_name("test");
+        assert_eq!(dummy.name(), String::from("test"));
+        dummy.signal_set(Signal::WRITABLE);
+        assert_eq!(dummy.signal(), Signal::WRITABLE);
+        dummy.signal_change(Signal::WRITABLE, Signal::READABLE);
+        assert_eq!(dummy.signal(), Signal::READABLE);
+
+        assert_eq!(dummy.get_child(0).unwrap_err(), ZxError::WRONG_TYPE);
+        assert_eq!(dummy.peer().unwrap_err(), ZxError::NOT_SUPPORTED);
+        assert_eq!(dummy.related_koid(), 0);
+        assert_eq!(dummy.allowed_signals(), Signal::USER_ALL);
+
+        assert_eq!(
+            format!("{:?}", dummy),
+            format!("DummyObject({}, \"test\")", dummy.id())
+        );
+    }
 }

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -531,6 +531,9 @@ mod tests {
             let flag = flag.clone();
             async move {
                 flag.store(1, Ordering::SeqCst);
+                // Assert an irrelevant signal to test the `false` branch of the callback for `READABLE`.
+                object.base.signal_set(Signal::USER_SIGNAL_0);
+                object.base.signal_clear(Signal::USER_SIGNAL_0);
                 object.base.signal_set(Signal::READABLE);
                 async_std::task::sleep(Duration::from_millis(10)).await;
 

--- a/zircon-object/src/object/rights.rs
+++ b/zircon-object/src/object/rights.rs
@@ -168,3 +168,14 @@ impl TryFrom<u32> for Rights {
         Self::from_bits(x).ok_or(ZxError::INVALID_ARGS)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_from() {
+        assert_eq!(Err(ZxError::INVALID_ARGS), Rights::try_from(0xffff_ffff));
+        assert_eq!(Ok(Rights::SAME_RIGHTS), Rights::try_from(1 << 31));
+    }
+}

--- a/zircon-object/src/object/signal.rs
+++ b/zircon-object/src/object/signal.rs
@@ -68,3 +68,21 @@ impl Signal {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_user_signal() {
+        assert_eq!(
+            Err(ZxError::INVALID_ARGS),
+            Signal::verify_user_signal(Signal::USER_ALL, 1 << 0)
+        );
+
+        assert_eq!(
+            Ok(Signal::USER_SIGNAL_0),
+            Signal::verify_user_signal(Signal::USER_ALL, 1 << 24)
+        );
+    }
+}

--- a/zircon-object/src/signal/port.rs
+++ b/zircon-object/src/signal/port.rs
@@ -185,6 +185,9 @@ mod tests {
             let object = object.clone();
             let packet2 = packet2.clone();
             async move {
+                // Assert an irrelevant signal to test the `false` branch of the callback for `READABLE`.
+                object.signal_set(Signal::USER_SIGNAL_0);
+                object.signal_clear(Signal::USER_SIGNAL_0);
                 object.signal_set(Signal::READABLE);
                 async_std::task::sleep(Duration::from_millis(1)).await;
                 port.push(packet2);
@@ -192,22 +195,35 @@ mod tests {
         });
 
         let packet = port.wait().await;
+        let packet_repr = PortPacketRepr {
+            key: 1,
+            status: ZxError::OK,
+            data: PayloadRepr::Signal(PacketSignal {
+                trigger: Signal::READABLE,
+                observed: Signal::READABLE,
+                count: 1,
+                timestamp: 0,
+                _reserved1: 0,
+            }),
+        };
         assert_eq!(
             PortPacketRepr::from(&packet),
-            PortPacketRepr {
-                key: 1,
-                status: ZxError::OK,
-                data: PayloadRepr::Signal(PacketSignal {
-                    trigger: Signal::READABLE,
-                    observed: Signal::READABLE,
-                    count: 1,
-                    timestamp: 0,
-                    _reserved1: 0,
-                }),
-            }
+            packet_repr
         );
 
         let packet = port.wait().await;
         assert_eq!(PortPacketRepr::from(&packet), packet2);
+
+
+        // Test asserting signal before `send_signal_to_port_async`.
+        let port = Port::new(0);
+        let object = DummyObject::new() as Arc<dyn KernelObject>;
+        object.signal_set(Signal::READABLE);
+        object.send_signal_to_port_async(Signal::READABLE, &port, 1);
+        let packet = port.wait().await;
+        assert_eq!(
+            PortPacketRepr::from(&packet),
+            packet_repr
+        );
     }
 }

--- a/zircon-object/src/signal/port.rs
+++ b/zircon-object/src/signal/port.rs
@@ -206,14 +206,10 @@ mod tests {
                 _reserved1: 0,
             }),
         };
-        assert_eq!(
-            PortPacketRepr::from(&packet),
-            packet_repr
-        );
+        assert_eq!(PortPacketRepr::from(&packet), packet_repr);
 
         let packet = port.wait().await;
         assert_eq!(PortPacketRepr::from(&packet), packet2);
-
 
         // Test asserting signal before `send_signal_to_port_async`.
         let port = Port::new(0);
@@ -221,9 +217,6 @@ mod tests {
         object.signal_set(Signal::READABLE);
         object.send_signal_to_port_async(Signal::READABLE, &port, 1);
         let packet = port.wait().await;
-        assert_eq!(
-            PortPacketRepr::from(&packet),
-            packet_repr
-        );
+        assert_eq!(PortPacketRepr::from(&packet), packet_repr);
     }
 }


### PR DESCRIPTION
- Add some trivial tests:
  - Test modules `object::handle`, `object::rights`, `object::signal`.
  - Test trait `KernelObject` using `DummyObject`.
  - Test some corner cases of `wait_signal` and `send_signal_to_port_async`.
  
  Now `zircon_object::object` is covered except 4 lines (unexpected, see https://github.com/mozilla/grcov/issues/467).

- Some minor refactors:
  - Use `KObjectBase::with()` to implement `with_signal()` and `with_name()`.
  - Add `signal_clear` in trait `KernelObject`.
  - Do not use `object.base` in tests.