### PR TITLE
Try to fix test `object::tests::wait_many`

### DIFF
--- a/zircon-object/Cargo.toml
+++ b/zircon-object/Cargo.toml
@@ -28,4 +28,4 @@ rvm = { git = "https://github.com/rcore-os/RVM", rev = "4b64355", optional = tru
 
 [dev-dependencies]
 kernel-hal-unix = { path = "../kernel-hal-unix" }
-async-std = { version = "1.5", features = ["attributes"] }
+async-std = { version = "1.5", features = ["attributes", "unstable"] }

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -280,7 +280,14 @@ impl KObjectBase {
     /// If true, the function will never be called again.
     pub fn add_signal_callback(&self, callback: SignalHandler) {
         let mut inner = self.inner.lock();
-        inner.signal_callbacks.push(callback);
+        // Check the callback immediately, in case that a signal arrives just before the call of
+        // `add_signal_callback` (since lock is acquired inside it) and the callback is not triggered
+        // in time.
+        if callback(inner.signal) {
+            return;
+        } else {
+            inner.signal_callbacks.push(callback);
+        }
     }
 }
 

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -526,61 +526,56 @@ impl DummyObject {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_std::sync::Barrier;
     use std::time::Duration;
 
     #[async_std::test]
     async fn wait() {
         let object = DummyObject::new();
-        let flag = Arc::new(AtomicU8::new(0));
-
+        let barrier = Arc::new(Barrier::new(2));
         async_std::task::spawn({
             let object = object.clone();
-            let flag = flag.clone();
+            let barrier = barrier.clone();
             async move {
-                flag.store(1, Ordering::SeqCst);
+                async_std::task::sleep(Duration::from_millis(20)).await;
+
                 // Assert an irrelevant signal to test the `false` branch of the callback for `READABLE`.
                 object.signal_set(Signal::USER_SIGNAL_0);
                 object.signal_clear(Signal::USER_SIGNAL_0);
                 object.signal_set(Signal::READABLE);
-                async_std::task::sleep(Duration::from_millis(10)).await;
+                barrier.wait().await;
 
-                flag.store(2, Ordering::SeqCst);
                 object.signal_set(Signal::WRITABLE);
             }
         });
         let object: Arc<dyn KernelObject> = object;
-        assert_eq!(flag.load(Ordering::SeqCst), 0);
 
         let signal = object.wait_signal(Signal::READABLE).await;
         assert_eq!(signal, Signal::READABLE);
-        assert_eq!(flag.load(Ordering::SeqCst), 1);
+        barrier.wait().await;
 
         let signal = object.wait_signal(Signal::WRITABLE).await;
         assert_eq!(signal, Signal::READABLE | Signal::WRITABLE);
-        assert_eq!(flag.load(Ordering::SeqCst), 2);
     }
 
     #[async_std::test]
     async fn wait_many() {
         let objs = [DummyObject::new(), DummyObject::new()];
-        let flag = Arc::new(AtomicU8::new(0));
-
+        let barrier = Arc::new(Barrier::new(2));
         async_std::task::spawn({
             let objs = objs.clone();
-            let flag = flag.clone();
+            let barrier = barrier.clone();
             async move {
-                async_std::task::sleep(Duration::from_millis(10)).await;
-                flag.store(1, Ordering::SeqCst);
-                objs[0].signal_set(Signal::READABLE);
-                async_std::task::sleep(Duration::from_millis(10)).await;
+                async_std::task::sleep(Duration::from_millis(20)).await;
 
-                flag.store(2, Ordering::SeqCst);
+                objs[0].signal_set(Signal::READABLE);
+                barrier.wait().await;
+
                 objs[1].signal_set(Signal::WRITABLE);
             }
         });
         let obj0: Arc<dyn KernelObject> = objs[0].clone();
         let obj1: Arc<dyn KernelObject> = objs[1].clone();
-        assert_eq!(flag.load(Ordering::SeqCst), 0);
 
         let signals = wait_signal_many(&[
             (obj0.clone(), Signal::READABLE),
@@ -588,7 +583,7 @@ mod tests {
         ])
         .await;
         assert_eq!(signals, [Signal::READABLE, Signal::empty()]);
-        assert_eq!(flag.load(Ordering::SeqCst), 1);
+        barrier.wait().await;
 
         let signals = wait_signal_many(&[
             (obj0.clone(), Signal::WRITABLE),
@@ -596,7 +591,6 @@ mod tests {
         ])
         .await;
         assert_eq!(signals, [Signal::READABLE, Signal::WRITABLE]);
-        assert_eq!(flag.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -283,9 +283,7 @@ impl KObjectBase {
         // Check the callback immediately, in case that a signal arrives just before the call of
         // `add_signal_callback` (since lock is acquired inside it) and the callback is not triggered
         // in time.
-        if callback(inner.signal) {
-            return;
-        } else {
+        if !callback(inner.signal) {
             inner.signal_callbacks.push(callback);
         }
     }

--- a/zircon-object/src/object/mod.rs
+++ b/zircon-object/src/object/mod.rs
@@ -562,6 +562,7 @@ mod tests {
             let objs = objs.clone();
             let flag = flag.clone();
             async move {
+                async_std::task::sleep(Duration::from_millis(10)).await;
                 flag.store(1, Ordering::SeqCst);
                 objs[0].signal_set(Signal::READABLE);
                 async_std::task::sleep(Duration::from_millis(10)).await;


### PR DESCRIPTION
Try to resolve https://github.com/rcore-os/zCore/issues/107

`object::tests::wait_many` occasionally failed, e.g., https://github.com/rcore-os/zCore/runs/885395893.

The failure is:
```
---- object::tests::wait_many stdout ----
thread 'object::tests::wait_many' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`', zircon-object/src/object/mod.rs:575:9
```
zircon-object/src/object/mod.rs:575 is
```Rust
assert_eq!(flag.load(Ordering::SeqCst), 0);
```

Actually I don't fully understand the useage of `flag`. I guess it is just used to indicate the program execution sequence. And I think the order of line 575 `assert_eq!(flag.load(Ordering::SeqCst), 0);` and the line 565 `flag.store(1, Ordering::SeqCst);` is uncertain, so the test sometimes fails. I think adding a `sleep` can help ensure the execution order.


btw, I still have some questions
- Why test `wait_many` fails, but `wait` doesn't?
- I can't reproduce the test failure on my mac.
- On my mac `wait_many` sometimes gets stuck (frequency ≈ 1 in 10). I didn't figure out the cause. Howerver, this `sleep` also fixed this, which surprised me……

![image](https://user-images.githubusercontent.com/37948597/87868984-39e55c00-c9ce-11ea-8452-c2c11690fe9c.png)