### PR TITLE
Fix out-of-memory panic

### DIFF
--- a/kernel-hal-bare/Cargo.toml
+++ b/kernel-hal-bare/Cargo.toml
@@ -23,7 +23,7 @@ uart_16550 = "0.2.6"
 raw-cpuid = "8.0"
 pc-keyboard = "0.5"
 apic = { git = "https://github.com/rcore-os/apic-rs", rev = "fb86bd7" }
-x86-smpboot = { git = "https://github.com/rcore-os/x86-smpboot", rev = "257d695" }
+x86-smpboot = { git = "https://github.com/rcore-os/x86-smpboot", rev = "43ffedf" }
 rcore-console = { git = "https://github.com/rcore-os/rcore-console", default-features = false, rev = "a980897b" }
 acpi = "1.0.0"
 

--- a/zircon-syscall/src/system.rs
+++ b/zircon-syscall/src/system.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 use {
     super::*,
-    alloc::boxed::Box,
     zircon_object::{signal::Event, task::Job},
 };
 
@@ -21,10 +20,8 @@ impl Syscall<'_> {
                 let proc = self.thread.proc();
                 proc.get_object_with_rights::<Job>(root_job, Rights::MANAGE_PROCESS)?
                     .check_root_job()?;
+                // TODO: out-of-memory event
                 let event = Event::new();
-                event.add_signal_callback(Box::new(|_| {
-                    panic!("Out Of Memory!");
-                }));
                 let event_handle = proc.add_handle(Handle::new(event, Rights::DEFAULT_EVENT));
                 out.write(event_handle)?;
                 Ok(())


### PR DESCRIPTION
Fix a panic on bare-metal zCore caused by #115 .

This PR also updates x86-smpboot crate by the way. Now application processors are able to run into userspace.