### PR TITLE
Add project template for building Zircon user programs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,25 @@ jobs:
           use-cross: true
           args: -p zircon-loader --target aarch64-unknown-linux-gnu
 
+  build-user:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull prebuilt images
+        run: git lfs pull -I prebuilt/zircon/x64/libc.so,prebuilt/zircon/x64/libfdio.so,prebuilt/zircon/x64/libunwind.so,prebuilt/zircon/x64/libzircon.so,prebuilt/zircon/x64/Scrt1.o
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2020-06-04
+          target: x86_64-fuchsia
+      - name: Build Zircon user programs
+        run: |
+          cd zircon-user
+          make build mode=release
+
   test:
     runs-on: ubuntu-20.04
     steps:
@@ -112,7 +131,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Pull prebuilt images
-        run: git lfs pull -X prebuilt/zircon/x64/bringup.zbi prebuilt/zircon/arm64
+        run: git lfs pull -I prebuilt/zircon/x64/core-tests.zbi,prebuilt/zircon/x64/libzircon.so,prebuilt/zircon/x64/userboot.so
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 exclude = [
+    "zircon-user",
 	"zCore",
 	"rboot",
 ]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Run Zircon on bare-metal (zCore):
 cd zCore && make run mode=release [graphic=on] [accel=1]
 ```
 
+Build and run your own Zircon user programs:
+
+```sh
+# See template in zircon-user
+cd zircon-user && make zbi mode=release
+
+# Run your programs in zCore
+cd zCore && make run mode=release user=1
+```
+
 To debug, set `RUST_LOG` environment variable to one of `error`, `warn`, `info`, `debug`, `trace`.
 
 ## Testing

--- a/prebuilt/zircon/x64/Scrt1.o
+++ b/prebuilt/zircon/x64/Scrt1.o
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be53277d9eb6c163b2fdc8111e4bdd9103f9b60af7ad848df1d0eb1cf76455e
+size 3280

--- a/prebuilt/zircon/x64/libc.so
+++ b/prebuilt/zircon/x64/libc.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64041bab309c272f98f99b27dd11bb05105e64918ed84f3c42ee4fd59047c48c
+size 3219152

--- a/prebuilt/zircon/x64/libfdio.so
+++ b/prebuilt/zircon/x64/libfdio.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65696f02592721187c155625187b3707a43d2aa74187173d39753837e374bfa4
+size 477280

--- a/prebuilt/zircon/x64/libunwind.so
+++ b/prebuilt/zircon/x64/libunwind.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b2a6513beb2b3aff74c421f9094829e4713cd92220c968348dba30185599ae9
+size 46560

--- a/prebuilt/zircon/x64/zbi-linux
+++ b/prebuilt/zircon/x64/zbi-linux
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2225efdb28deeac624b0e00b8f0e7e589145f327ea02fc7e90d02218bb2c97e
+size 1037760

--- a/prebuilt/zircon/x64/zbi-macos
+++ b/prebuilt/zircon/x64/zbi-macos
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59355c4c94e5ebd7cf66fc9cf4530891401390a37c0bc72cccfe4da51a089d3f
+size 1055988

--- a/zCore/Makefile
+++ b/zCore/Makefile
@@ -4,6 +4,7 @@ zbi_file ?= bringup
 graphic ?=
 accel ?=
 linux ?=
+user ?=
 hypervisor ?=
 smp ?= 1
 test_filter ?= *.*
@@ -92,6 +93,9 @@ $(kernel_img): kernel bootloader
 	cp rboot.conf $(ESP)/EFI/Boot/rboot.conf
 ifeq ($(linux), 1)
 	cp x86_64.img $(ESP)/EFI/zCore/fuchsia.zbi
+else ifeq ($(user), 1)
+	make -C ../zircon-user
+	cp ../zircon-user/target/zcore.zbi $(ESP)/EFI/zCore/fuchsia.zbi
 else
 	cp ../prebuilt/zircon/x64/$(zbi_file).zbi $(ESP)/EFI/zCore/fuchsia.zbi
 endif

--- a/zircon-user/.cargo/config
+++ b/zircon-user/.cargo/config
@@ -1,0 +1,7 @@
+[build]
+target = "x86_64-fuchsia"
+
+[target.x86_64-fuchsia]
+rustflags = [
+    "-L", "../prebuilt/zircon/x64",
+]

--- a/zircon-user/Cargo.toml
+++ b/zircon-user/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zircon-user"
+version = "0.1.0"
+authors = ["Runji Wang <wangrunji0408@163.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/zircon-user/Makefile
+++ b/zircon-user/Makefile
@@ -1,0 +1,33 @@
+mode ?= debug
+
+ZBI_IN := ../prebuilt/zircon/x64/bringup.zbi
+ZBI_OUT := target/zcore.zbi
+BUILD_DIR := target/x86_64-fuchsia/$(mode)
+BOOTFS := $(BUILD_DIR)/bootfs
+BINS := $(patsubst src/bin/%.rs, $(BOOTFS)/bin/%, $(wildcard src/bin/*.rs))
+
+ifeq ($(mode), release)
+	BUILD_ARGS += --release
+endif
+
+ifeq ($(shell uname), Darwin)
+	ZBI_CLI := ../prebuilt/zircon/x64/zbi-macos
+else
+	ZBI_CLI := ../prebuilt/zircon/x64/zbi-linux
+endif
+
+.PHONY: zbi
+
+all: zbi
+
+zbi: $(ZBI_OUT)
+
+build:
+	cargo build $(BUILD_ARGS)
+
+$(BOOTFS)/bin/%: $(BUILD_DIR)/%
+	mkdir -p $(BOOTFS)/bin
+	cp $^ $@
+
+$(ZBI_OUT): build $(BINS)
+	$(ZBI_CLI) $(ZBI_IN) $(BOOTFS) -o $@

--- a/zircon-user/src/bin/hello.rs
+++ b/zircon-user/src/bin/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, zCore!");
+}


### PR DESCRIPTION
This PR adds a template project `zircon-user` with some prebuilt files from official Fuchsia SDK.

After that, we can easily build our own Zircon user programs in Rust, then run and test it in zCore.