### PR TITLE
Improve docs and tests for `zircon_object::signal`

### DIFF
--- a/zircon-object/src/signal/event.rs
+++ b/zircon-object/src/signal/event.rs
@@ -22,10 +22,26 @@ impl_kobject!(Event
 define_count_helper!(Event);
 
 impl Event {
+    /// Create a new `Event`.
     pub fn new() -> Arc<Self> {
         Arc::new(Event {
             base: KObjectBase::default(),
             _counter: CountHelper::new(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_allowed_signals() {
+        let event = Event::new();
+        assert!(Signal::verify_user_signal(
+            event.allowed_signals(),
+            (Signal::USER_SIGNAL_5 | Signal::SIGNALED).bits().into()
+        )
+        .is_ok());
     }
 }

--- a/zircon-object/src/signal/eventpair.rs
+++ b/zircon-object/src/signal/eventpair.rs
@@ -70,12 +70,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_allowed_signals() {
+        let (event0, event1) = EventPair::create();
+        assert!(Signal::verify_user_signal(
+            event0.allowed_signals(),
+            (Signal::USER_SIGNAL_5 | Signal::SIGNALED).bits().into()
+        )
+        .is_ok());
+        assert_eq!(event0.allowed_signals(), event1.allowed_signals());
+
+        event0.peer().unwrap();
+    }
+
+    #[test]
     fn peer_closed() {
         let (event0, event1) = EventPair::create();
         assert!(Arc::ptr_eq(&event0.peer().unwrap(), &event1));
+        assert_eq!(event0.related_koid(), event1.id());
 
         drop(event1);
         assert_eq!(event0.signal(), Signal::PEER_CLOSED);
         assert_eq!(event0.peer().err(), Some(ZxError::PEER_CLOSED));
+        assert_eq!(event0.related_koid(), 0);
     }
 }

--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -33,6 +33,13 @@ struct FutexInner {
 
 impl Futex {
     /// Create a new Futex.
+    ///
+    /// The parameter `value` is the reference to
+    /// an userspace `AtomicI32`. This reference is the
+    /// information used in kernel to track what futex given threads are
+    /// waiting on. The kernel does not currently modify the value of
+    /// `*value`. It is up to userspace code to correctly atomically modify this
+    /// value across threads in order to build mutexes and so on.
     pub fn new(value: &'static AtomicI32) -> Arc<Self> {
         Arc::new(Futex {
             base: KObjectBase::default(),
@@ -295,6 +302,7 @@ impl Waiter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::{Job, Process, ThreadState};
     use core::time::Duration;
 
     #[async_std::test]
@@ -321,5 +329,97 @@ mod tests {
         // wait for wake.
         futex.wait(1).await.unwrap();
         assert_eq!(VALUE.load(Ordering::SeqCst), 2);
+        assert_eq!(futex.wake(1), 0);
+    }
+
+    #[async_std::test]
+    async fn requeue() {
+        static VALUE: AtomicI32 = AtomicI32::new(1);
+        let futex = Futex::new(&VALUE);
+        static REQUEUE_VALUE: AtomicI32 = AtomicI32::new(100);
+        let requeue_futex = Futex::new(&REQUEUE_VALUE);
+
+        let count = futex.wake(1);
+        assert_eq!(count, 0);
+
+        // inconsistent value should fail.
+        assert_eq!(futex.wait(0).await, Err(ZxError::BAD_STATE));
+
+        // spawn a new task to wait
+        {
+            let futex = futex.clone();
+            async_std::task::spawn(async move {
+                futex.wait(1).await.unwrap();
+            });
+        }
+        // spawn a new task to requeue.
+        {
+            let futex = futex.clone();
+            async_std::task::spawn(async move {
+                async_std::task::sleep(Duration::from_millis(10)).await;
+                VALUE.store(2, Ordering::SeqCst);
+                // inconsistent value should fail.
+                assert_eq!(
+                    futex.requeue(1, 1, 1, &requeue_futex, None),
+                    Err(ZxError::BAD_STATE)
+                );
+                assert!(futex.requeue(2, 1, 1, &requeue_futex, None).is_ok());
+            });
+        }
+        // wait for wake.
+        futex.wait(1).await.unwrap();
+        assert_eq!(VALUE.load(Ordering::SeqCst), 2);
+    }
+
+    #[async_std::test]
+    async fn owner() {
+        let root_job = Job::root();
+        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
+        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+
+        static VALUE: AtomicI32 = AtomicI32::new(1);
+        let futex = proc.get_futex(&VALUE);
+        assert!(futex.owner().is_none());
+        futex.inner.lock().set_owner(Some(thread.clone()));
+
+        {
+            let futex = futex.clone();
+            let thread = thread.clone();
+            async_std::task::spawn(async move {
+                futex
+                    .wait_with_owner(1, Some(thread.clone()), Some(thread))
+                    .await
+                    .unwrap();
+            });
+        }
+        async_std::task::sleep(Duration::from_millis(10)).await;
+        assert_eq!(
+            futex
+                .wait_with_owner(1, Some(thread.clone()), Some(thread.clone()))
+                .await
+                .unwrap_err(),
+            ZxError::INVALID_ARGS
+        );
+
+        futex.inner.lock().set_owner(None);
+        futex.wake_single_owner();
+        assert!(Arc::ptr_eq(&futex.owner().unwrap(), &thread));
+        assert_eq!(futex.wake(1), 0);
+    }
+
+    #[async_std::test]
+    async fn time_out() {
+        let root_job = Job::root();
+        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
+        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+
+        static VALUE: AtomicI32 = AtomicI32::new(1);
+        let futex = proc.get_futex(&VALUE);
+        let future = futex.wait_with_owner(1, Some(thread.clone()), Some(thread.clone()));
+        let result: ZxResult = thread
+            .blocking_run(future, ThreadState::BlockedFutex, Duration::from_millis(1))
+            .await;
+        assert_eq!(result.unwrap_err(), ZxError::TIMED_OUT);
+        assert_eq!(futex.wake(1), 0);
     }
 }

--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -153,14 +153,11 @@ impl Futex {
             fn drop(&mut self) {
                 let inner = self.waiter.inner.lock();
                 if !inner.woken {
-                    if let Some(thread) = &self.waiter.thread {
-                        let futex = thread.proc().get_futex(inner.futex.value);
-                        let queue = &mut futex.inner.lock().waiter_queue;
-                        if let Some(pos) = queue.iter().position(|x| Arc::ptr_eq(&x, &self.waiter))
-                        {
-                            // Nobody cares about the order of queue, so just remove faster
-                            queue.swap_remove_back(pos);
-                        }
+                    let futex = inner.futex.clone();
+                    let queue = &mut futex.inner.lock().waiter_queue;
+                    if let Some(pos) = queue.iter().position(|x| Arc::ptr_eq(&x, &self.waiter)) {
+                        // Nobody cares about the order of queue, so just remove faster
+                        queue.swap_remove_back(pos);
                     }
                 }
             }

--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -69,7 +69,7 @@ impl Futex {
             if let Some(waiter) = inner.waiter_queue.pop_front() {
                 waiter.wake();
             } else {
-                return i + 1;
+                return i;
             }
         }
         wake_count
@@ -304,6 +304,9 @@ mod tests {
     async fn wait() {
         static VALUE: AtomicI32 = AtomicI32::new(1);
         let futex = Futex::new(&VALUE);
+
+        let count = futex.wake(1);
+        assert_eq!(count, 0);
 
         // inconsistent value should fail.
         assert_eq!(futex.wait(0).await, Err(ZxError::BAD_STATE));

--- a/zircon-object/src/signal/mod.rs
+++ b/zircon-object/src/signal/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Objects for signaling and waiting.
 
 use super::*;

--- a/zircon-object/src/signal/port.rs
+++ b/zircon-object/src/signal/port.rs
@@ -154,8 +154,11 @@ impl Port {
 }
 
 bitflags! {
+    /// If you need this port to be bound to an interrupt, pass **BIND_TO_INTERRUPT** to *options*,
+    /// otherwise it should be **0**.
     pub struct PortOptions: u32 {
         #[allow(clippy::identity_op)]
+        /// Allow this port to be bound to an interrupt.
         const BIND_TO_INTERUPT         = 1 << 0;
     }
 }

--- a/zircon-object/src/signal/port.rs
+++ b/zircon-object/src/signal/port.rs
@@ -106,7 +106,8 @@ impl Port {
         inner.interrupt_grave.remove(&pid)
     }
 
-    /// Asynchronous wait until at least one packet is available, then take out all packets.
+    /// Asynchronous wait until at least one packet is available, then take out the earliest
+    /// (in FIFO order) available packet.
     pub async fn wait(self: &Arc<Self>) -> PortPacket {
         let object = self.clone() as Arc<dyn KernelObject>;
         loop {

--- a/zircon-object/src/signal/port_packet.rs
+++ b/zircon-object/src/signal/port_packet.rs
@@ -236,8 +236,8 @@ impl PartialEq for PacketGuestVcpu {
     #[allow(unsafe_code)]
     fn eq(&self, other: &Self) -> bool {
         if !self.type_.eq(&other.type_)
-            || self._padding1.eq(&other._padding1)
-            || self._reserved.eq(&other._reserved)
+            || !self._padding1.eq(&other._padding1)
+            || !self._reserved.eq(&other._reserved)
         {
             return false;
         }
@@ -289,5 +289,139 @@ mod tests {
         assert_eq!(size_of::<PacketGuestIo>(), 32);
         assert_eq!(size_of::<PacketGuestVcpu>(), 32);
         assert_eq!(size_of::<PacketInterrupt>(), 32);
+    }
+
+    fn test_encdec(data: PayloadRepr) {
+        let repr = PortPacketRepr {
+            key: 0,
+            status: ZxError::OK,
+            data: data.clone(),
+        };
+        let packet = PortPacket {
+            key: 0,
+            type_: data.type_(),
+            status: ZxError::OK,
+            data: data.encode(),
+        };
+        assert_eq!(repr, PortPacketRepr::from(&packet));
+        assert_eq!(repr.clone(), PortPacketRepr::from(&PortPacket::from(repr)));
+    }
+
+    #[test]
+    fn user() {
+        let user = PacketUser::default();
+        test_encdec(PayloadRepr::User(user));
+    }
+
+    #[test]
+    fn signal() {
+        let data = PacketSignal {
+            trigger: Signal::READABLE,
+            observed: Signal::WRITABLE,
+            count: 1,
+            timestamp: 0,
+            _reserved1: 0,
+        };
+        test_encdec(PayloadRepr::Signal(data));
+        let packet = PortPacket {
+            key: 1,
+            type_: PacketType::SignalOne,
+            status: ZxError::OK,
+            data: Payload { signal: data },
+        };
+        let packet_ = PortPacket {
+            key: 1,
+            type_: PacketType::SignalRep,
+            status: ZxError::OK,
+            data: Payload { signal: data },
+        };
+        assert_eq!(
+            PortPacketRepr::from(&packet),
+            PortPacketRepr::from(&packet_)
+        );
+    }
+
+    #[test]
+    fn guest_bell() {
+        let guest_bell = PacketGuestBell::default();
+        assert_eq!(guest_bell.addr, 0);
+        test_encdec(PayloadRepr::GuestBell(guest_bell));
+    }
+
+    #[test]
+    fn guest_mem() {
+        let guest_mem = PacketGuestMem::default();
+        assert_eq!(guest_mem.addr, 0);
+        test_encdec(PayloadRepr::GuestMem(guest_mem));
+    }
+
+    #[test]
+    fn guest_io() {
+        let guest_io = PacketGuestIo::default();
+        assert_eq!(guest_io.port, 0);
+        assert_eq!(guest_io.input, false);
+        test_encdec(PayloadRepr::GuestIo(guest_io));
+    }
+
+    #[test]
+    fn guest_vcpu() {
+        let interrupt = PacketGuestVcpuInterrupt { mask: 0, vector: 0 };
+        let guest_vcpu1 = PacketGuestVcpu {
+            data: PacketGuestVcpuData { interrupt },
+            type_: PacketGuestVcpuType::VcpuInterrupt,
+            _padding1: Default::default(),
+            _reserved: 0,
+        };
+        let startup = PacketGuestVcpuStartup { id: 0, entry: 0 };
+        let guest_vcpu2 = PacketGuestVcpu {
+            data: PacketGuestVcpuData { startup },
+            type_: PacketGuestVcpuType::VcpuStartup,
+            _padding1: Default::default(),
+            _reserved: 0,
+        };
+        test_encdec(PayloadRepr::GuestVcpu(guest_vcpu1));
+        test_encdec(PayloadRepr::GuestVcpu(guest_vcpu2));
+
+        let packet = PortPacket {
+            key: 1,
+            type_: PacketType::GuestVcpu,
+            status: ZxError::OK,
+            data: Payload {
+                guest_vcpu: guest_vcpu2,
+            },
+        };
+        assert_eq!(
+            format!("{:?}", packet),
+            "PortPacketRepr { key: 1, status: OK, data: GuestVcpu(PacketGuestVcpu { data: PacketGuestVcpuStartup { id: 0, entry: 0 }, type_: VcpuStartup, _padding1: [0, 0, 0, 0, 0, 0, 0], _reserved: 0 }) }"
+        );
+
+        assert!(!guest_vcpu1.eq(&guest_vcpu2));
+        let guest_vcpu3 = PacketGuestVcpu {
+            data: PacketGuestVcpuData {
+                startup: PacketGuestVcpuStartup { id: 0, entry: 1 },
+            },
+            type_: PacketGuestVcpuType::VcpuStartup,
+            _padding1: Default::default(),
+            _reserved: 0,
+        };
+        assert!(!guest_vcpu2.eq(&guest_vcpu3));
+    }
+
+    #[test]
+    fn interrupt() {
+        let interrupt = PacketInterrupt {
+            timestamp: 12345,
+            _reserved0: 0,
+            _reserved1: 0,
+            _reserved2: 0,
+        };
+        test_encdec(PayloadRepr::Interrupt(interrupt));
+    }
+
+    #[test]
+    #[should_panic(expected = "not implemented")]
+    fn page_request() {
+        let data: PacketUser = [0u8; 32];
+        PayloadRepr::decode(PacketType::PageRequest, &Payload { user: data });
     }
 }

--- a/zircon-object/src/signal/port_packet.rs
+++ b/zircon-object/src/signal/port_packet.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 //! Port packet data structure definition.
 
 use super::*;
@@ -15,6 +16,7 @@ pub struct PortPacket {
 }
 
 // reference: zircon/system/public/zircon/syscalls/port.h ZX_PKT_TYPE_*
+/// The type of a packet.
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum PacketType {
@@ -30,6 +32,7 @@ pub enum PacketType {
 }
 
 #[repr(C)]
+/// The data carried by a packet
 pub union Payload {
     user: PacketUser,
     signal: PacketSignal,

--- a/zircon-object/src/signal/timer.rs
+++ b/zircon-object/src/signal/timer.rs
@@ -27,10 +27,15 @@ struct TimerInner {
     deadline: Option<Duration>,
 }
 
-#[derive(Debug)]
+/// Slack specifies how much a timer or event is allowed to deviate from its deadline.
+///
+/// **Not supported: Now slack has no effect on the timer.**
 pub enum Slack {
+    /// slack is centered around deadline
     Center,
+    /// slack interval is (deadline - slack, deadline]
     Early,
+    /// slack interval is [deadline, deadline + slack)
     Late,
 }
 
@@ -94,6 +99,16 @@ impl Timer {
 mod tests {
     use super::*;
     use kernel_hal::timer_now;
+
+    #[test]
+    fn one_shot() {
+        let timer = Timer::one_shot(timer_now() + Duration::from_millis(15));
+        std::thread::sleep(Duration::from_millis(10));
+        assert_eq!(timer.signal(), Signal::empty());
+
+        std::thread::sleep(Duration::from_millis(20));
+        assert_eq!(timer.signal(), Signal::SIGNALED);
+    }
 
     #[test]
     fn set() {

--- a/zircon-syscall/src/port.rs
+++ b/zircon-syscall/src/port.rs
@@ -6,7 +6,7 @@ use {
 impl Syscall<'_> {
     pub fn sys_port_create(&self, options: u32, mut out: UserOutPtr<HandleValue>) -> ZxResult {
         info!("port.create: options={:#x}", options);
-        let port_handle = Handle::new(Port::new(options), Rights::DEFAULT_PORT);
+        let port_handle = Handle::new(Port::new(options)?, Rights::DEFAULT_PORT);
         let handle_value = self.thread.proc().add_handle(port_handle);
         out.write(handle_value)?;
         Ok(())


### PR DESCRIPTION
# Content of this PR
- `zircon_object::signal` passed `#![deny(missing_docs)]`, but `#![allow(missing_docs)]` is added in `signal::port_packet`.
Since `port_packet` just defines some C-style data types and the names can convey meanings, I think it is fine to omit docs.
- `zircon_object::signal` test coverage increases to 96.4%.
- Some minor refactors
  - validate `options` in `Port::new()`
  - refactor `FutexFuture::drop`: using `waiter.inner.futex` instead of `waiter.thread.proc().get_futex()`
- Some minor fixes
  - The doc of `port.wait` says it takes out all packets, but only takes out one in fact.
  - The return count of `futex.wake` is wrong.

PTAL and see whether the changes are proper. Besides, I still have
# Some questions
## timer
1. `Slack` is useless. What's the plan about it?

## port
1. Is it OK that many structs in `port_packet` are public?
2. Where should the validation of `options` be done? Low level `Port::new()` or high level syscalls? Or both? Should `Interrupt::bind()` validate `port.can_bind_to_interrupt()` again? (It is not validated now, so we can pass a port without `BIND_TO_INTERUPT` option actually)
I'm a little bit confused about such kind of questions. 

## futex
**I'm not very familiar with futex, so I might have understood some concepts wrong**

1. Should futex only be created by `proc.get_futex()` and not by `Futex::new`? Otherwise the futex cannot be bound to some thread. This question arises from this situation:
```rust
static VALUE: AtomicI32 = AtomicI32::new(1);
let futex = Futex::new(&VALUE);

let root_job = Job::root();
let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
assert!(!Arc::ptr_eq(&futex, &thread.proc().get_futex(&VALUE)));
```
This is kind of like the question mentioned above about validating port `options`, where the low level primitives are misused . So who is responsible to ensure the correctness? Should the object methods be robust enough themselves, or just let the user obey some contracts?
2. What's the use of `waiter.thread` (and the parameter `thread` in `Futex::wait_with_owner()`)? It is reasonable that the waiter knows which thread is waiting...But it can be set to `None`? And I think it is not used anywhere actually.