### PR TITLE
Improve docs and tests for `zircon_object::ipc`

### DIFF
--- a/zircon-object/src/ipc/channel.rs
+++ b/zircon-object/src/ipc/channel.rs
@@ -11,6 +11,21 @@ use {
 };
 
 /// Bidirectional interprocess communication
+///
+/// # SYNOPSIS
+///
+/// A channel is a bidirectional transport of messages consisting of some
+/// amount of byte data and some number of handles.
+///
+/// # DESCRIPTION
+///
+/// The process of sending a message via a channel has two steps. The first is to
+/// atomically write the data into the channel and move ownership of all handles in
+/// the message into this channel. This operation always consumes the handles: at
+/// the end of the call, all handles either are all in the channel or are all
+/// discarded. The second operation, channel read, is similar: on success
+/// all the handles in the next message are atomically moved into the
+/// receiving process' handle table. On failure, the channel retains ownership.
 pub struct Channel {
     base: KObjectBase,
     _counter: CountHelper,
@@ -143,9 +158,13 @@ impl Drop for Channel {
     }
 }
 
+/// The message transferred in the channel.
+/// See [Channel](struct.Channel.html) for details.
 #[derive(Default)]
 pub struct MessagePacket {
+    /// The data carried by the message packet
     pub data: Vec<u8>,
+    /// See [Channel](struct.Channel.html) for details.
     pub handles: Vec<Handle>,
 }
 

--- a/zircon-object/src/ipc/channel.rs
+++ b/zircon-object/src/ipc/channel.rs
@@ -102,9 +102,9 @@ impl Channel {
     /// Write a packet to the channel
     pub fn write(&self, msg: T) -> ZxResult {
         let peer = self.peer.upgrade().ok_or(ZxError::PEER_CLOSED)?;
-        if msg.data.len() >= 4 {
-            // check first 4 bytes: whether it is a call reply?
-            let txid = TxID::from_ne_bytes(msg.data[..4].try_into().unwrap());
+        // check first 4 bytes: whether it is a call reply?
+        let txid = msg.get_txid();
+        if txid != 0 {
             if let Some(sender) = peer.call_reply.lock().remove(&txid) {
                 let _ = sender.send(Ok(msg));
                 return Ok(());
@@ -115,10 +115,17 @@ impl Channel {
     }
 
     /// Send a message to a channel and await a reply.
+    ///
+    /// The first four bytes of the written and read back messages are treated as a
+    /// transaction ID.  The kernel generates a txid for the
+    /// written message, replacing that part of the message as read from userspace.
+    ///
+    /// `msg.data` must have at lease a length of 4 bytes.
     pub async fn call(self: &Arc<Self>, mut msg: T) -> ZxResult<T> {
+        assert!(msg.data.len() >= 4);
         let peer = self.peer.upgrade().ok_or(ZxError::PEER_CLOSED)?;
         let txid = self.new_txid();
-        msg.data[..4].copy_from_slice(&txid.to_ne_bytes());
+        msg.set_txid(txid);
         peer.push_general(msg);
         let (sender, receiver) = oneshot::channel();
         self.call_reply.lock().insert(txid, sender);
@@ -160,7 +167,7 @@ impl Drop for Channel {
 
 /// The message transferred in the channel.
 /// See [Channel](struct.Channel.html) for details.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct MessagePacket {
     /// The data carried by the message packet
     pub data: Vec<u8>,
@@ -168,11 +175,44 @@ pub struct MessagePacket {
     pub handles: Vec<Handle>,
 }
 
+impl MessagePacket {
+    /// Set txid (the first 4 bytes)
+    pub fn set_txid(&mut self, txid: TxID) {
+        if self.data.len() >= core::mem::size_of::<TxID>() {
+            self.data[..4].copy_from_slice(&txid.to_ne_bytes());
+        }
+    }
+
+    /// Get txid (the first 4 bytes)
+    pub fn get_txid(&self) -> TxID {
+        if self.data.len() >= core::mem::size_of::<TxID>() {
+            TxID::from_ne_bytes(self.data[..4].try_into().unwrap())
+        } else {
+            0
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloc::boxed::Box;
     use core::sync::atomic::*;
+    use core::time::Duration;
+
+    #[test]
+    fn test_basics() {
+        let (end0, end1) = Channel::create();
+        assert!(Arc::ptr_eq(
+            &end0.peer().unwrap().downcast_arc().unwrap(),
+            &end1
+        ));
+        assert_eq!(end0.related_koid(), end1.id());
+
+        drop(end1);
+        assert_eq!(end0.peer().unwrap_err(), ZxError::PEER_CLOSED);
+        assert_eq!(end0.related_koid(), 0);
+    }
 
     #[test]
     fn read_write() {
@@ -257,5 +297,69 @@ mod tests {
         assert!(!peer_closed.load(Ordering::SeqCst));
         drop(channel1);
         assert!(peer_closed.load(Ordering::SeqCst));
+    }
+
+    #[async_std::test]
+    async fn call() {
+        let (channel0, channel1) = Channel::create();
+        async_std::task::spawn({
+            let channel1 = channel1.clone();
+            async move {
+                async_std::task::sleep(Duration::from_millis(10)).await;
+                let recv_msg = channel1.read().unwrap();
+                let txid = recv_msg.get_txid();
+                assert_eq!(txid, 0x8000_0000);
+                assert_eq!(txid.to_ne_bytes(), &recv_msg.data[..4]);
+                assert_eq!(&recv_msg.data[4..], b"o 0");
+                // write an irrelevant message
+                channel1
+                    .write(MessagePacket {
+                        data: Vec::from("hello 1"),
+                        handles: Vec::new(),
+                    })
+                    .unwrap();
+                // reply the call
+                let mut data: Vec<u8> = vec![];
+                data.append(&mut txid.to_ne_bytes().to_vec());
+                data.append(&mut Vec::from("hello 2"));
+                channel1
+                    .write(MessagePacket {
+                        data,
+                        handles: Vec::new(),
+                    })
+                    .unwrap();
+            }
+        });
+
+        let recv_msg = channel0
+            .call(MessagePacket {
+                data: Vec::from("hello 0"),
+                handles: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let txid = recv_msg.get_txid();
+        assert_eq!(txid, 0x8000_0000);
+        assert_eq!(txid.to_ne_bytes(), &recv_msg.data[..4]);
+        assert_eq!(&recv_msg.data[4..], b"hello 2");
+
+        // peer dropped when calling
+        let (channel0, channel1) = Channel::create();
+        async_std::task::spawn({
+            async move {
+                async_std::task::sleep(Duration::from_millis(10)).await;
+                let _ = channel1;
+            }
+        });
+        assert_eq!(
+            channel0
+                .call(MessagePacket {
+                    data: Vec::from("hello 0"),
+                    handles: Vec::new(),
+                })
+                .await
+                .unwrap_err(),
+            ZxError::PEER_CLOSED
+        );
     }
 }

--- a/zircon-object/src/ipc/fifo.rs
+++ b/zircon-object/src/ipc/fifo.rs
@@ -62,8 +62,10 @@ impl Fifo {
     /// in the fifo to contain all of them.
     ///
     /// The number of elements actually written is returned.
+    ///
+    /// `count` must be nonzero.
     pub fn write(&self, elem_size: usize, data: &[u8], count: usize) -> ZxResult<usize> {
-        if elem_size != self.elem_size {
+        if elem_size != self.elem_size || count == 0 {
             return Err(ZxError::OUT_OF_RANGE);
         }
         let count_size = count * elem_size;
@@ -97,8 +99,10 @@ impl Fifo {
     /// The `elem_size` must match the element size that was passed into `Fifo::create()`.
     ///
     /// `data` must have a size of `count * elem_size` bytes.
-    pub fn read(&self, elem_size: usize, count: usize, data: &mut [u8]) -> ZxResult<usize> {
-        if elem_size != self.elem_size {
+    ///
+    /// `count` must be nonzero.
+    pub fn read(&self, elem_size: usize, data: &mut [u8], count: usize) -> ZxResult<usize> {
+        if elem_size != self.elem_size || count == 0 {
             return Err(ZxError::OUT_OF_RANGE);
         }
         let count_size = count * elem_size;

--- a/zircon-object/src/ipc/fifo.rs
+++ b/zircon-object/src/ipc/fifo.rs
@@ -7,9 +7,14 @@ use {
 
 /// First-In First-Out inter-process queue.
 ///
+/// # SYNOPSIS
+///
 /// FIFOs are intended to be the control plane for shared memory transports.
-/// Their read and write operations are more efficient than sockets or channels,
+/// Their read and write operations are more efficient than [`sockets`] or [`channels`],
 /// but there are severe restrictions on the size of elements and buffers.
+///
+/// [`sockets`]: ../socket/struct.Socket.html
+/// [`channels`]: ../channel/struct.Channel.html
 pub struct Fifo {
     base: KObjectBase,
     peer: Weak<Fifo>,
@@ -143,5 +148,64 @@ impl Drop for Fifo {
             peer.base
                 .signal_change(Signal::WRITABLE, Signal::PEER_CLOSED);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_basics() {
+        let (end0, end1) = Fifo::create(10, 5);
+        assert!(Arc::ptr_eq(
+            &end0.peer().unwrap().downcast_arc().unwrap(),
+            &end1
+        ));
+        assert_eq!(end0.related_koid(), end1.id());
+
+        drop(end1);
+        assert_eq!(end0.peer().unwrap_err(), ZxError::PEER_CLOSED);
+        assert_eq!(end0.related_koid(), 0);
+    }
+
+    #[test]
+    fn read_write() {
+        let (end0, end1) = Fifo::create(2, 5);
+
+        assert_eq!(
+            end0.write(4, &[0; 9], 1).unwrap_err(),
+            ZxError::OUT_OF_RANGE
+        );
+        assert_eq!(
+            end0.write(5, &[0; 0], 0).unwrap_err(),
+            ZxError::OUT_OF_RANGE
+        );
+        let data = (0..15).collect::<Vec<u8>>();
+        assert_eq!(end0.write(5, data.as_slice(), 3).unwrap(), 2);
+        assert_eq!(
+            end0.write(5, data.as_slice(), 3).unwrap_err(),
+            ZxError::SHOULD_WAIT
+        );
+
+        let mut buf = [0; 15];
+        assert_eq!(
+            end1.read(4, &mut [0; 4], 1).unwrap_err(),
+            ZxError::OUT_OF_RANGE
+        );
+        assert_eq!(end1.read(5, &mut [], 0).unwrap_err(), ZxError::OUT_OF_RANGE);
+        assert_eq!(end1.read(5, &mut buf, 3).unwrap(), 2);
+        let mut data = (0..10).collect::<Vec<u8>>();
+        data.append(&mut vec![0; 5]);
+        assert_eq!(buf, data.as_slice());
+        assert_eq!(end1.read(5, &mut buf, 3).unwrap_err(), ZxError::SHOULD_WAIT);
+
+        drop(end1);
+        assert_eq!(
+            end0.write(5, data.as_slice(), 3).unwrap_err(),
+            ZxError::PEER_CLOSED
+        );
+        assert_eq!(end0.read(5, &mut buf, 3).unwrap_err(), ZxError::PEER_CLOSED);
     }
 }

--- a/zircon-object/src/ipc/mod.rs
+++ b/zircon-object/src/ipc/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Objects for IPC.
 
 mod channel;

--- a/zircon-object/src/ipc/socket.rs
+++ b/zircon-object/src/ipc/socket.rs
@@ -290,7 +290,7 @@ impl Socket {
             self_size
         };
         SocketInfo {
-            options: self.flags.bits(),
+            options: self.flags.bits() as u32,
             padding1: 0,
             rx_buf_max: SOCKET_SIZE as _,
             rx_buf_size: self_size as _,

--- a/zircon-object/src/ipc/socket.rs
+++ b/zircon-object/src/ipc/socket.rs
@@ -78,12 +78,6 @@ impl Socket {
             return Err(ZxError::INVALID_ARGS);
         }
         let starting_signals: Signal = Signal::WRITABLE;
-        // if flags.contains(SocketFlags::HAS_ACCEPT) {
-        //     starting_signals |= Signal::SOCKET_SHARE;
-        // }
-        // if flags.contains(SocketFlags::HAS_CONTROL) {
-        //     starting_signals |= Signal::SOCKET_CONTROL_WRITABLE;
-        // }
         let mut end0 = Arc::new(Socket {
             base: KObjectBase::with_signal(starting_signals),
             peer: Weak::default(),
@@ -393,4 +387,255 @@ pub struct SocketInfo {
     rx_buf_available: u64,
     tx_buf_max: u64,
     tx_buf_size: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basics() {
+        assert_eq!(Socket::create(1 << 10).unwrap_err(), ZxError::INVALID_ARGS);
+        assert_eq!(
+            Socket::create(SocketFlags::SOCKET_PEEK.bits).unwrap_err(),
+            ZxError::INVALID_ARGS
+        );
+        let (end0, end1) = Socket::create(1).unwrap();
+        assert!(Arc::ptr_eq(
+            &end0.peer().unwrap().downcast_arc().unwrap(),
+            &end1
+        ));
+        assert_eq!(end0.related_koid(), end1.id());
+
+        drop(end1);
+        assert_eq!(end0.peer().unwrap_err(), ZxError::PEER_CLOSED);
+        assert_eq!(end0.related_koid(), 0);
+    }
+
+    #[test]
+    fn test_stream() {
+        let (end0, end1) = Socket::create(0).unwrap();
+
+        // empty read & write
+        assert_eq!(
+            end0.read(false, &mut [0; 10]).unwrap_err(),
+            ZxError::SHOULD_WAIT
+        );
+        assert_eq!(end0.write(&[]).unwrap(), 0);
+
+        assert_eq!(end0.write(&[1, 2, 3]), Ok(3));
+        let mut buf = [0u8; 4];
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 3);
+        assert_eq!(buf, [1, 2, 3, 0]);
+        buf = [0; 4];
+        // can read again
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 3);
+        assert_eq!(buf, [1, 2, 3, 0]);
+        assert_eq!(
+            end0.get_info(),
+            SocketInfo {
+                options: 0,
+                padding1: 0,
+                rx_buf_max: SOCKET_SIZE as _,
+                rx_buf_size: 0,
+                rx_buf_available: 0,
+                tx_buf_max: SOCKET_SIZE as _,
+                tx_buf_size: 3,
+            }
+        );
+
+        // use a small buffer now
+        let mut buf = [0u8; 2];
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 2);
+        assert_eq!(buf, [1, 2]);
+        // consume
+        assert_eq!(end1.read(false, &mut buf).unwrap(), 2);
+        assert_eq!(buf, [1, 2]);
+        assert_eq!(end1.read(false, &mut buf).unwrap(), 1);
+        assert_eq!(buf, [3, 2]);
+
+        end1.write(&[111, 233, 222]).unwrap();
+        assert_eq!(
+            end0.get_info(),
+            SocketInfo {
+                options: 0,
+                padding1: 0,
+                rx_buf_max: SOCKET_SIZE as _,
+                rx_buf_size: 3,
+                rx_buf_available: 3,
+                tx_buf_max: SOCKET_SIZE as _,
+                tx_buf_size: 0,
+            }
+        );
+
+        // write much data
+        assert_eq!(end0.write(&[0; SOCKET_SIZE * 2]).unwrap(), SOCKET_SIZE);
+        assert_eq!(end0.write(&[0; 1]).unwrap_err(), ZxError::SHOULD_WAIT);
+        assert!(!end0.signal().contains(Signal::WRITABLE));
+        end1.read(false, &mut [0; 1]).unwrap();
+        assert!(end0.signal().contains(Signal::WRITABLE));
+    }
+
+    #[test]
+    fn test_datagram() {
+        let (end0, end1) = Socket::create(1).unwrap();
+
+        // empty read & write
+        assert_eq!(
+            end0.read(false, &mut [0; 10]).unwrap_err(),
+            ZxError::SHOULD_WAIT
+        );
+        assert_eq!(end0.write(&[]).unwrap_err(), ZxError::INVALID_ARGS);
+
+        assert_eq!(end0.write(&[1, 2, 3]), Ok(3));
+        assert_eq!(end0.write(&[4, 5, 6, 7]), Ok(4));
+
+        let mut buf = [0u8; 4];
+        assert_eq!(end1.read(true, &mut []).unwrap(), 0);
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 3);
+        assert_eq!(buf, [1, 2, 3, 0]);
+        buf = [0; 4];
+        // can read again
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 3);
+        assert_eq!(buf, [1, 2, 3, 0]);
+        assert_eq!(
+            end0.get_info(),
+            SocketInfo {
+                options: SocketFlags::DATAGRAM.bits,
+                padding1: 0,
+                rx_buf_max: SOCKET_SIZE as _,
+                rx_buf_size: 0,
+                rx_buf_available: 0,
+                tx_buf_max: SOCKET_SIZE as _,
+                tx_buf_size: 7,
+            }
+        );
+        assert_eq!(
+            end1.get_info(),
+            SocketInfo {
+                options: SocketFlags::DATAGRAM.bits,
+                padding1: 0,
+                rx_buf_max: SOCKET_SIZE as _,
+                rx_buf_size: 7,
+                rx_buf_available: 3,
+                tx_buf_max: SOCKET_SIZE as _,
+                tx_buf_size: 0,
+            }
+        );
+
+        // use a small buffer now
+        let mut buf = [0u8; 2];
+        assert_eq!(end1.read(true, &mut buf).unwrap(), 2);
+        assert_eq!(buf, [1, 2]);
+        // consume
+        assert_eq!(end1.read(false, &mut buf).unwrap(), 2);
+        assert_eq!(buf, [1, 2]);
+        assert_eq!(end1.read(false, &mut buf).unwrap(), 2);
+        assert_eq!(buf, [4, 5]);
+
+        // write much data
+        let (end0, end1) = Socket::create(1).unwrap();
+        assert_eq!(
+            end0.write(&[0; SOCKET_SIZE * 2]).unwrap_err(),
+            ZxError::OUT_OF_RANGE
+        );
+        assert_eq!(end0.write(&[0; SOCKET_SIZE]).unwrap(), SOCKET_SIZE);
+        assert!(!end0.signal().contains(Signal::WRITABLE));
+        end1.read(false, &mut [0; 1]).unwrap();
+        assert!(end0.signal().contains(Signal::WRITABLE));
+    }
+
+    #[test]
+    fn test_threshold() {
+        let (end0, end1) = Socket::create(0).unwrap();
+        assert_eq!(end0.get_rx_tx_threshold(), (0, 0));
+
+        // write
+        assert_eq!(
+            end0.set_write_threshold(SOCKET_SIZE * 2).unwrap_err(),
+            ZxError::INVALID_ARGS
+        );
+        // have space when setting threshold
+        assert!(end0.set_write_threshold(10).is_ok());
+        assert!(end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        assert_eq!(end0.get_rx_tx_threshold(), (0, 10));
+        end0.write(&[0; SOCKET_SIZE - 9]).unwrap();
+        assert!(!end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        // no space when setting threshold
+        assert!(end0.set_write_threshold(20).is_ok());
+        assert!(!end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        end1.read(false, &mut [0; 10]).unwrap();
+        assert!(!end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        end1.read(false, &mut [0; 1]).unwrap();
+        assert!(end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        // disable threshold
+        assert!(end0.set_write_threshold(0).is_ok());
+        assert!(!end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+
+        // read
+        assert_eq!(
+            end0.set_read_threshold(SOCKET_SIZE * 2).unwrap_err(),
+            ZxError::INVALID_ARGS
+        );
+        // have data when setting threshold
+        end1.write(&[0; 10]).unwrap();
+        assert!(end0.set_read_threshold(10).is_ok());
+        assert!(end0.signal().contains(Signal::SOCKET_READ_THRESHOLD));
+        assert_eq!(end0.get_rx_tx_threshold(), (10, 0));
+        end0.read(false, &mut [0; 1]).unwrap();
+        assert!(!end0.signal().contains(Signal::SOCKET_READ_THRESHOLD));
+        // no data when setting threshold
+        end0.read(false, &mut [0; 10]).unwrap();
+        assert!(end0.set_read_threshold(20).is_ok());
+        assert!(!end0.signal().contains(Signal::SOCKET_WRITE_THRESHOLD));
+        end1.write(&[0; 10]).unwrap();
+        assert!(!end0.signal().contains(Signal::SOCKET_READ_THRESHOLD));
+        end1.write(&[0; 10]).unwrap();
+        assert!(end0.signal().contains(Signal::SOCKET_READ_THRESHOLD));
+        // disable threshold
+        assert!(end0.set_read_threshold(0).is_ok());
+        assert!(!end0.signal().contains(Signal::SOCKET_READ_THRESHOLD));
+    }
+
+    #[test]
+    fn test_shutdown() {
+        let (end0, end1) = Socket::create(0).unwrap();
+        end0.write(&[0; 10]).unwrap();
+
+        assert!(end1.shutdown(true, false).is_ok());
+        assert_eq!(end0.write(&[0; 1]).unwrap_err(), ZxError::BAD_STATE);
+        assert!(!end0.signal().contains(Signal::WRITABLE));
+        // buffered data can be read
+        assert!(end1.signal().contains(Signal::READABLE));
+        assert_eq!(end1.read(false, &mut [0; 20]).unwrap(), 10);
+        // no more data
+        assert!(!end1.signal().contains(Signal::READABLE));
+        assert_eq!(
+            end1.read(false, &mut [0; 20]).unwrap_err(),
+            ZxError::BAD_STATE
+        );
+        // the opposite direction is still okay
+        assert_eq!(end1.write(&[0; 1]).unwrap(), 1);
+        assert_eq!(end0.read(false, &mut [0; 10]).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_drop() {
+        let (end0, end1) = Socket::create(0).unwrap();
+        end0.write(&[0; 10]).unwrap();
+
+        drop(end0);
+        assert!(!end1.signal().contains(Signal::WRITABLE));
+        assert!(end1.signal().contains(Signal::PEER_CLOSED));
+        assert_eq!(end1.write(&[0; 1]).unwrap_err(), ZxError::PEER_CLOSED);
+        // buffered data can be read
+        assert!(end1.signal().contains(Signal::READABLE));
+        assert_eq!(end1.read(false, &mut [0; 20]).unwrap(), 10);
+        // no more data
+        assert!(!end1.signal().contains(Signal::READABLE));
+        assert_eq!(
+            end1.read(false, &mut [0; 20]).unwrap_err(),
+            ZxError::PEER_CLOSED
+        );
+    }
 }

--- a/zircon-object/src/ipc/socket.rs
+++ b/zircon-object/src/ipc/socket.rs
@@ -137,9 +137,9 @@ impl Socket {
     }
 
     fn write_data(&self, data: &[u8]) -> ZxResult<usize> {
-        let data_len = self.inner.lock().data.len();
-        let was_empty = data_len == 0;
-        let rest_size = SOCKET_SIZE - data_len;
+        let curr_size = self.inner.lock().data.len();
+        let was_empty = curr_size == 0;
+        let rest_size = SOCKET_SIZE - curr_size;
         if rest_size == 0 {
             return Err(ZxError::SHOULD_WAIT);
         }
@@ -193,8 +193,8 @@ impl Socket {
     ///
     /// If `peek` is true, leave the message in the socket.
     pub fn read(&self, peek: bool, data: &mut [u8]) -> ZxResult<usize> {
-        let data_len = self.inner.lock().data.len();
-        if data_len == 0 {
+        let curr_size = self.inner.lock().data.len();
+        if curr_size == 0 {
             let _peer = self.peer.upgrade().ok_or(ZxError::PEER_CLOSED)?;
             let inner = self.inner.lock();
             if inner.read_disabled {
@@ -202,7 +202,7 @@ impl Socket {
             }
             return Err(ZxError::SHOULD_WAIT);
         }
-        let was_full = data_len == SOCKET_SIZE;
+        let was_full = curr_size == SOCKET_SIZE;
         let actual_count = if self.flags.contains(SocketFlags::DATAGRAM) {
             self.read_datagram(data, peek)?
         } else {

--- a/zircon-syscall/src/fifo.rs
+++ b/zircon-syscall/src/fifo.rs
@@ -70,7 +70,7 @@ impl Syscall<'_> {
         let fifo = proc.get_object_with_rights::<Fifo>(handle_value, Rights::READ)?;
         // TODO: uninit buffer
         let mut data = vec![0; elem_size * count];
-        let actual_count = fifo.read(elem_size, count, &mut data)?;
+        let actual_count = fifo.read(elem_size, &mut data, count)?;
         actual_count_ptr.write_if_not_null(actual_count)?;
         user_bytes.write_array(&data)?;
         Ok(())

--- a/zircon-syscall/src/socket.rs
+++ b/zircon-syscall/src/socket.rs
@@ -32,14 +32,13 @@ impl Syscall<'_> {
         if count > 0 && user_bytes.is_null() {
             return Err(ZxError::INVALID_ARGS);
         }
-        let options = SocketFlags::from_bits(options).ok_or(ZxError::INVALID_ARGS)?;
-        if !(options - SocketFlags::SOCKET_CONTROL).is_empty() {
+        if options != 0 {
             return Err(ZxError::INVALID_ARGS);
         }
         let proc = self.thread.proc();
         let socket = proc.get_object_with_rights::<Socket>(handle_value, Rights::WRITE)?;
         let data = user_bytes.read_array(count)?;
-        let actual_count = socket.write(options, &data)?;
+        let actual_count = socket.write(&data)?;
         actual_count_ptr.write_if_not_null(actual_count)?;
         Ok(())
     }
@@ -60,7 +59,7 @@ impl Syscall<'_> {
             return Err(ZxError::INVALID_ARGS);
         }
         let options = SocketFlags::from_bits(options).ok_or(ZxError::INVALID_ARGS)?;
-        if !(options - SocketFlags::SOCKET_CONTROL - SocketFlags::SOCKET_PEEK).is_empty() {
+        if !(options - SocketFlags::SOCKET_PEEK).is_empty() {
             return Err(ZxError::INVALID_ARGS);
         }
         let proc = self.thread.proc();

--- a/zircon-syscall/src/socket.rs
+++ b/zircon-syscall/src/socket.rs
@@ -65,7 +65,8 @@ impl Syscall<'_> {
         let proc = self.thread.proc();
         let socket = proc.get_object_with_rights::<Socket>(handle_value, Rights::READ)?;
         let mut data = vec![0; count];
-        let actual_count = socket.read(options, &mut data)?;
+        let peek = options.contains(SocketFlags::SOCKET_PEEK);
+        let actual_count = socket.read(peek, &mut data)?;
         user_bytes.write_array(&data)?;
         actual_count_ptr.write_if_not_null(actual_count)?;
         Ok(())


### PR DESCRIPTION
- `ipc` passes `#![deny(missing_docs)]`
- add some tests

# Other changes
## Socket
- delete deprecated options and methods (about control) 
- fix `SocketInfo`: `tx_buf_max` should also be 0 if no peer
- some minor refactors
  - remove the `option` param for `read/write`
  - rename `data_len` (to `curr_size`) which may be mistaken fo `data.len()`

## Fifo
- `count` should be nonzero in `read/write`. Swap the param order of `Fifo::read` to make it the same as `Fifo::write`

**Question**: In zCore now, `Fifo::read/write` assert `data.len()==count * elem_size`. 
zircon `zx_fifo_read` just says *data* must have a size of at least `count * elem_size` bytes. Don't know what happen if `data` is not big enough. UB? So 
- Should the restriction be changed?
- Using an `assert` or returning `Err`, which one is better?

## Channel
- `msg.data.len() >= 4` in `call`. Whether needed? Since syscall already checks that.
