### PR TITLE
Improve docs for `linux-syscall` and fix "uname" command

### DIFF
--- a/linux-syscall/src/file/dir.rs
+++ b/linux-syscall/src/file/dir.rs
@@ -16,7 +16,7 @@ use kernel_hal::user::UserOutPtr;
 use linux_object::fs::vfs::FileType;
 
 impl Syscall<'_> {
-    /// return a null-terminated string containing an absolute pathname 
+    /// return a null-terminated string containing an absolute pathname
     /// that is the current working directory of the calling process.
     /// `buf` – pointer to buffer to receive path
     /// `len` – size of buf
@@ -54,7 +54,7 @@ impl Syscall<'_> {
         self.sys_mkdirat(FileDesc::CWD, path, mode)
     }
 
-    /// create directory relative to directory file descriptor 
+    /// create directory relative to directory file descriptor
     pub fn sys_mkdirat(&self, dirfd: FileDesc, path: UserInPtr<u8>, mode: usize) -> SysResult {
         let path = path.read_cstring()?;
         // TODO: check pathname
@@ -89,7 +89,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// get directory entries 
+    /// get directory entries
     /// TODO: get ino from dirent
     /// - fd – file describe
     pub fn sys_getdents64(
@@ -125,13 +125,13 @@ impl Syscall<'_> {
         Ok(writer.written_size)
     }
 
-    /// creates a new link (also known as a hard link) to an existing file. 
+    /// creates a new link (also known as a hard link) to an existing file.
     pub fn sys_link(&self, oldpath: UserInPtr<u8>, newpath: UserInPtr<u8>) -> SysResult {
         self.sys_linkat(FileDesc::CWD, oldpath, FileDesc::CWD, newpath, 0)
     }
 
-    /// create file link relative to directory file descriptors 
-    /// If the pathname given in oldpath is relative, 
+    /// create file link relative to directory file descriptors
+    /// If the pathname given in oldpath is relative,
     /// then it is interpreted relative to the directory referred to by the file descriptor olddirfd
     pub fn sys_linkat(
         &self,
@@ -157,7 +157,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// delete name/possibly file it refers to 
+    /// delete name/possibly file it refers to
     /// If that name was the last link to a file and no processes have the file open, the file is deleted.
     /// If the name was the last link to a file but any processes still have the file open,
     /// the file will remain in existence until the last file descriptor referring to it is closed.
@@ -165,7 +165,7 @@ impl Syscall<'_> {
         self.sys_unlinkat(FileDesc::CWD, path, 0)
     }
 
-    /// remove directory entry relative to directory file descriptor 
+    /// remove directory entry relative to directory file descriptor
     /// The unlinkat() system call operates in exactly the same way as either unlink or rmdir.
     pub fn sys_unlinkat(&self, dirfd: FileDesc, path: UserInPtr<u8>, flags: usize) -> SysResult {
         let path = path.read_cstring()?;
@@ -191,7 +191,7 @@ impl Syscall<'_> {
         self.sys_renameat(FileDesc::CWD, oldpath, FileDesc::CWD, newpath)
     }
 
-    /// rename file relative to directory file descriptors 
+    /// rename file relative to directory file descriptors
     pub fn sys_renameat(
         &self,
         olddirfd: FileDesc,
@@ -215,12 +215,12 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// read value of symbolic link 
+    /// read value of symbolic link
     pub fn sys_readlink(&self, path: UserInPtr<u8>, base: UserOutPtr<u8>, len: usize) -> SysResult {
         self.sys_readlinkat(FileDesc::CWD, path, base, len)
     }
 
-    /// read value of symbolic link relative to directory file descriptor 
+    /// read value of symbolic link relative to directory file descriptor
     /// readlink() places the contents of the symbolic link path in the buffer base, which has size len
     /// TODO: recursive link resolution and loop detection
     pub fn sys_readlinkat(

--- a/linux-syscall/src/file/dir.rs
+++ b/linux-syscall/src/file/dir.rs
@@ -18,8 +18,8 @@ use linux_object::fs::vfs::FileType;
 impl Syscall<'_> {
     /// return a null-terminated string containing an absolute pathname
     /// that is the current working directory of the calling process.
-    /// `buf` – pointer to buffer to receive path
-    /// `len` – size of buf
+    /// - `buf` – pointer to buffer to receive path
+    /// - `len` – size of buf
     pub fn sys_getcwd(&self, mut buf: UserOutPtr<u8>, len: usize) -> SysResult {
         info!("getcwd: buf={:?}, len={:#x}", buf, len);
         let proc = self.linux_process();

--- a/linux-syscall/src/file/fd.rs
+++ b/linux-syscall/src/file/fd.rs
@@ -13,7 +13,7 @@ impl Syscall<'_> {
         self.sys_openat(FileDesc::CWD, path, flags, mode)
     }
 
-    /// open file relative to directory file descriptor 
+    /// open file relative to directory file descriptor
     pub fn sys_openat(
         &self,
         dir_fd: FileDesc,
@@ -62,7 +62,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// create a copy of the file descriptor oldfd. 
+    /// create a copy of the file descriptor oldfd.
     pub fn sys_dup2(&self, fd1: FileDesc, fd2: FileDesc) -> SysResult {
         info!("dup2: from {:?} to {:?}", fd1, fd2);
         let proc = self.linux_process();

--- a/linux-syscall/src/file/fd.rs
+++ b/linux-syscall/src/file/fd.rs
@@ -8,10 +8,12 @@
 use super::*;
 
 impl Syscall<'_> {
+    /// Opens or creates a file, depending on the flags passed to the call. Returns an integer with the file descriptor.
     pub fn sys_open(&self, path: UserInPtr<u8>, flags: usize, mode: usize) -> SysResult {
         self.sys_openat(FileDesc::CWD, path, flags, mode)
     }
 
+    /// open file relative to directory file descriptor 
     pub fn sys_openat(
         &self,
         dir_fd: FileDesc,
@@ -52,6 +54,7 @@ impl Syscall<'_> {
         Ok(fd.into())
     }
 
+    /// Closes a file descriptor, so that it no longer refers to any file and may be reused.
     pub fn sys_close(&self, fd: FileDesc) -> SysResult {
         info!("close: fd={:?}", fd);
         let proc = self.linux_process();
@@ -59,6 +62,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
+    /// create a copy of the file descriptor oldfd. 
     pub fn sys_dup2(&self, fd1: FileDesc, fd2: FileDesc) -> SysResult {
         info!("dup2: from {:?} to {:?}", fd1, fd2);
         let proc = self.linux_process();
@@ -127,14 +131,17 @@ bitflags! {
 }
 
 impl OpenFlags {
+    /// check if the OpenFlags is readable
     fn readable(self) -> bool {
         let b = self.bits() & 0b11;
         b == Self::RDONLY.bits() || b == Self::RDWR.bits()
     }
+    /// check if the OpenFlags is writable
     fn writable(self) -> bool {
         let b = self.bits() & 0b11;
         b == Self::WRONLY.bits() || b == Self::RDWR.bits()
     }
+    /// convert OpenFlags to OpenOptions
     fn to_options(self) -> OpenOptions {
         OpenOptions {
             read: self.readable(),

--- a/linux-syscall/src/file/file.rs
+++ b/linux-syscall/src/file/file.rs
@@ -12,7 +12,7 @@
 use super::*;
 
 impl Syscall<'_> {
-    /// Reads from a specified file using a file descriptor. Before using this call, 
+    /// Reads from a specified file using a file descriptor. Before using this call,
     /// you must first obtain a file descriptor using the opensyscall. Returns bytes read successfully.
     /// - fd – file descriptor
     /// - base – pointer to the buffer to fill with read contents
@@ -27,7 +27,7 @@ impl Syscall<'_> {
         Ok(len)
     }
 
-    /// Writes to a specified file using a file descriptor. Before using this call, 
+    /// Writes to a specified file using a file descriptor. Before using this call,
     /// you must first obtain a file descriptor using the open syscall. Returns bytes written successfully.
     /// - fd – file descriptor
     /// - base – pointer to the buffer write
@@ -41,8 +41,8 @@ impl Syscall<'_> {
         Ok(len)
     }
 
-    /// read from or write to a file descriptor at a given offset 
-    /// reads up to count bytes from file descriptor fd at offset offset 
+    /// read from or write to a file descriptor at a given offset
+    /// reads up to count bytes from file descriptor fd at offset offset
     /// (from the start of the file) into the buffer starting at buf. The file offset is not changed.
     pub fn sys_pread(
         &self,
@@ -63,8 +63,8 @@ impl Syscall<'_> {
         Ok(len)
     }
 
-    /// writes up to count bytes from the buffer 
-    /// starting at buf to the file descriptor fd at offset offset. The file offset is not changed. 
+    /// writes up to count bytes from the buffer
+    /// starting at buf to the file descriptor fd at offset offset. The file offset is not changed.
     pub fn sys_pwrite(
         &self,
         fd: FileDesc,
@@ -83,8 +83,8 @@ impl Syscall<'_> {
         Ok(len)
     }
 
-    /// works just like read except that multiple buffers are filled. 
-    /// reads iov_count buffers from the file 
+    /// works just like read except that multiple buffers are filled.
+    /// reads iov_count buffers from the file
     /// associated with the file descriptor fd into the buffers described by iov ("scatter input")
     pub fn sys_readv(
         &self,
@@ -103,8 +103,8 @@ impl Syscall<'_> {
     }
 
     /// works just like write except that multiple buffers are written out.
-    /// writes iov_count buffers of data described 
-    /// by iov to the file associated with the file descriptor fd ("gather output"). 
+    /// writes iov_count buffers of data described
+    /// by iov to the file associated with the file descriptor fd ("gather output").
     pub fn sys_writev(
         &self,
         fd: FileDesc,
@@ -123,7 +123,7 @@ impl Syscall<'_> {
         Ok(len)
     }
 
-    /// repositions the offset of the open file associated with the file descriptor fd 
+    /// repositions the offset of the open file associated with the file descriptor fd
     /// to the argument offset according to the directive whence
     pub fn sys_lseek(&self, fd: FileDesc, offset: i64, whence: u8) -> SysResult {
         const SEEK_SET: u8 = 0;
@@ -144,7 +144,7 @@ impl Syscall<'_> {
         Ok(offset as usize)
     }
 
-    /// cause the regular file named by path to be truncated to a size of precisely length bytes. 
+    /// cause the regular file named by path to be truncated to a size of precisely length bytes.
     pub fn sys_truncate(&self, path: UserInPtr<u8>, len: usize) -> SysResult {
         let path = path.read_cstring()?;
         info!("truncate: path={:?}, len={}", path, len);
@@ -153,7 +153,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// cause the regular file referenced by fd to be truncated to a size of precisely length bytes. 
+    /// cause the regular file referenced by fd to be truncated to a size of precisely length bytes.
     pub fn sys_ftruncate(&self, fd: FileDesc, len: usize) -> SysResult {
         info!("ftruncate: fd={:?}, len={}", fd, len);
         let proc = self.linux_process();
@@ -250,7 +250,7 @@ impl Syscall<'_> {
         Ok(total_written)
     }
 
-    /// causes all buffered modifications to file metadata and data to be written to the underlying file systems. 
+    /// causes all buffered modifications to file metadata and data to be written to the underlying file systems.
     pub fn sys_sync(&self) -> SysResult {
         info!("sync:");
         let proc = self.linux_process();
@@ -258,7 +258,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// transfers ("flushes") all modified in-core data of (i.e., modified buffer cache pages for) the file 
+    /// transfers ("flushes") all modified in-core data of (i.e., modified buffer cache pages for) the file
     /// referred to by the file descriptor fd to the disk device
     pub fn sys_fsync(&self, fd: FileDesc) -> SysResult {
         info!("fsync: fd={:?}", fd);
@@ -308,7 +308,7 @@ impl Syscall<'_> {
         self.sys_faccessat(FileDesc::CWD, path, mode, 0)
     }
 
-    /// Check user's permissions of a file relative to a directory file descriptor 
+    /// Check user's permissions of a file relative to a directory file descriptor
     /// TODO: check permissions based on uid/gid
     pub fn sys_faccessat(
         &self,

--- a/linux-syscall/src/file/mod.rs
+++ b/linux-syscall/src/file/mod.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 use super::*;
 use bitflags::bitflags;
 use linux_object::fs::vfs::{FileType, FsError};

--- a/linux-syscall/src/file/mod.rs
+++ b/linux-syscall/src/file/mod.rs
@@ -1,3 +1,4 @@
+//! Syscalls for files
 #![deny(missing_docs)]
 use super::*;
 use bitflags::bitflags;

--- a/linux-syscall/src/file/stat.rs
+++ b/linux-syscall/src/file/stat.rs
@@ -8,6 +8,10 @@ use super::*;
 use linux_object::fs::vfs::{FileType, Metadata};
 
 impl Syscall<'_> {
+    /// Works exactly like the stat syscall, but if the file in question is a symbolic link, 
+    /// information on the link is returned rather than its target.
+    /// - `path` – full path to file
+    /// - `stat_ptr` – pointer to stat buffer
     pub fn sys_lstat(&self, path: UserInPtr<u8>, stat_ptr: UserOutPtr<Stat>) -> SysResult {
         self.sys_fstatat(
             FileDesc::CWD,
@@ -17,6 +21,9 @@ impl Syscall<'_> {
         )
     }
 
+    /// Works exactly like the stat syscall except a file descriptor (fd) is provided instead of a path.
+    /// - `fd` – file descriptor
+    /// - `stat_ptr` – pointer to stat buffer
     pub fn sys_fstat(&self, fd: FileDesc, mut stat_ptr: UserOutPtr<Stat>) -> SysResult {
         info!("fstat: fd={:?}, stat_ptr={:?}", fd, stat_ptr);
         let proc = self.linux_process();
@@ -26,6 +33,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
+    /// get file status relative to a directory file descriptor 
     pub fn sys_fstatat(
         &self,
         dirfd: FileDesc,
@@ -48,6 +56,9 @@ impl Syscall<'_> {
         Ok(0)
     }
 
+    /// Returns information about a file in a structure named stat.
+    /// - `path` – pointer to the name of the file
+    /// - `stat_ptr` –  pointer to the structure to receive file information
     pub fn sys_stat(&self, path: UserInPtr<u8>, stat_ptr: UserOutPtr<Stat>) -> SysResult {
         self.sys_fstatat(FileDesc::CWD, path, stat_ptr, 0)
     }

--- a/linux-syscall/src/file/stat.rs
+++ b/linux-syscall/src/file/stat.rs
@@ -8,7 +8,7 @@ use super::*;
 use linux_object::fs::vfs::{FileType, Metadata};
 
 impl Syscall<'_> {
-    /// Works exactly like the stat syscall, but if the file in question is a symbolic link, 
+    /// Works exactly like the stat syscall, but if the file in question is a symbolic link,
     /// information on the link is returned rather than its target.
     /// - `path` – full path to file
     /// - `stat_ptr` – pointer to stat buffer
@@ -33,7 +33,7 @@ impl Syscall<'_> {
         Ok(0)
     }
 
-    /// get file status relative to a directory file descriptor 
+    /// get file status relative to a directory file descriptor
     pub fn sys_fstatat(
         &self,
         dirfd: FileDesc,

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -1,4 +1,23 @@
 //! Linux syscall implementations
+//!
+//! ## Example
+//! the syscall is called like this in the linux-loader:
+//! ```
+//! //   let num = regs.rax as u32;
+//! //   let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
+//! //   let mut syscall = Syscall {
+//! //       thread,
+//! //       #[cfg(feature = "std")]
+//! //       syscall_entry: kernel_hal_unix::syscall_entry as usize,
+//! //       #[cfg(not(feature = "std"))]
+//! //       syscall_entry: 0,
+//! //       spawn_fn: spawn,
+//! //       regs,
+//! //      exit: false,
+//! //   };
+//! //   let ret = syscall.syscall(num, args).await;
+//! ```
+//!
 
 #![no_std]
 #![deny(
@@ -33,22 +52,6 @@ mod time;
 mod vm;
 
 /// The struct of Syscall which stores the information about making a syscall
-/// the syscall is called like this in the linux-loader:
-/// ```
-/// let num = regs.rax as u32;
-/// let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
-/// let mut syscall = Syscall {
-///     thread,
-///     #[cfg(feature = "std")]
-///     syscall_entry: kernel_hal_unix::syscall_entry as usize,
-///     #[cfg(not(feature = "std"))]
-///     syscall_entry: 0,
-///     spawn_fn: spawn,
-///     regs,
-///     exit: false,
-/// };
-/// let ret = syscall.syscall(num, args).await;
-/// ```
 pub struct Syscall<'a> {
     /// the thread making a syscall
     pub thread: &'a Arc<Thread>,

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -1,7 +1,13 @@
 //! Linux syscall implementations
 
 #![no_std]
-#![deny(warnings, unsafe_code, unused_must_use, unreachable_patterns)]
+#![deny(
+    warnings,
+    unsafe_code,
+    unused_must_use,
+    unreachable_patterns,
+    missing_docs
+)]
 #![feature(bool_to_option)]
 
 #[macro_use]
@@ -26,16 +32,38 @@ mod task;
 mod time;
 mod vm;
 
+/// The struct of Syscall which stores the information about making a syscall
+/// the syscall is called like this in the linux-loader:
+/// ```
+/// let num = regs.rax as u32;
+/// let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
+/// let mut syscall = Syscall {
+///     thread,
+///     #[cfg(feature = "std")]
+///     syscall_entry: kernel_hal_unix::syscall_entry as usize,
+///     #[cfg(not(feature = "std"))]
+///     syscall_entry: 0,
+///     spawn_fn: spawn,
+///     regs,
+///     exit: false,
+/// };
+/// let ret = syscall.syscall(num, args).await;
+/// ```
 pub struct Syscall<'a> {
+    /// the thread making a syscall
     pub thread: &'a Arc<Thread>,
+    /// the entry of current syscall
     pub syscall_entry: VirtAddr,
+    /// store the regs statues
     pub regs: &'a mut GeneralRegs,
+    /// the spawn function in linux-loader
     pub spawn_fn: fn(thread: Arc<Thread>),
     /// Set `true` to exit current task.
     pub exit: bool,
 }
 
 impl Syscall<'_> {
+    /// syscall entry function
     pub async fn syscall(&mut self, num: u32, args: [usize; 6]) -> isize {
         debug!("syscall: num={}, args={:x?}", num, args);
         let sys_type = match Sys::try_from(num) {
@@ -205,6 +233,7 @@ impl Syscall<'_> {
     }
 
     #[cfg(target_arch = "x86_64")]
+    /// syscall specified for x86_64
     async fn x86_64_syscall(&mut self, sys_type: Sys, args: [usize; 6]) -> SysResult {
         let [a0, a1, a2, _a3, _a4, _a5] = args;
         match sys_type {
@@ -235,6 +264,7 @@ impl Syscall<'_> {
         }
     }
 
+    /// unkown syscalls, currently is similar to unimplemented syscalls but emit an error
     fn unknown_syscall(&mut self, sys_type: Sys) -> SysResult {
         error!("unknown syscall: {:?}. exit...", sys_type);
         let proc = self.zircon_process();
@@ -243,15 +273,18 @@ impl Syscall<'_> {
         Err(LxError::ENOSYS)
     }
 
+    /// unimplemented syscalls
     fn unimplemented(&self, name: &str, ret: SysResult) -> SysResult {
         warn!("{}: unimplemented", name);
         ret
     }
 
+    /// get zircon process
     fn zircon_process(&self) -> &Arc<Process> {
         self.thread.proc()
     }
 
+    /// get linux process
     fn linux_process(&self) -> &LinuxProcess {
         self.zircon_process().linux()
     }

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -2,20 +2,20 @@
 //!
 //! ## Example
 //! the syscall is called like this in the linux-loader:
-//! ```
-//! //   let num = regs.rax as u32;
-//! //   let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
-//! //   let mut syscall = Syscall {
-//! //       thread,
-//! //       #[cfg(feature = "std")]
-//! //       syscall_entry: kernel_hal_unix::syscall_entry as usize,
-//! //       #[cfg(not(feature = "std"))]
-//! //       syscall_entry: 0,
-//! //       spawn_fn: spawn,
-//! //       regs,
-//! //      exit: false,
-//! //   };
-//! //   let ret = syscall.syscall(num, args).await;
+//! ```ignore
+//! let num = regs.rax as u32;
+//! let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
+//! let mut syscall = Syscall {
+//!     thread,
+//!     #[cfg(feature = "std")]
+//!     syscall_entry: kernel_hal_unix::syscall_entry as usize,
+//!     #[cfg(not(feature = "std"))]
+//!     syscall_entry: 0,
+//!     spawn_fn: spawn,
+//!     regs,
+//!     exit: false,
+//! };
+//! let ret = syscall.syscall(num, args).await;
 //! ```
 //!
 

--- a/linux-syscall/src/misc.rs
+++ b/linux-syscall/src/misc.rs
@@ -19,7 +19,7 @@ impl Syscall<'_> {
     pub fn sys_uname(&self, buf: UserOutPtr<u8>) -> SysResult {
         info!("uname: buf={:?}", buf);
 
-        let strings = ["rCore", "orz", "0.1.0", "1", "machine", "domain"];
+        let strings = ["zCore", "orz", "0.1.0", "1", "machine", "domain"];
         for (i, &s) in strings.iter().enumerate() {
             const OFFSET: usize = 65;
             buf.add(i * OFFSET).write_cstring(s)?;

--- a/linux-syscall/src/misc.rs
+++ b/linux-syscall/src/misc.rs
@@ -22,7 +22,7 @@ impl Syscall<'_> {
     pub fn sys_uname(&self, buf: UserOutPtr<u8>) -> SysResult {
         info!("uname: buf={:?}", buf);
 
-        let strings = ["zCore", "orz", "0.1.0", "1", "machine", "domain"];
+        let strings = ["Linux", "orz", "0.1.0", "1", "machine", "domain"];
         for (i, &s) in strings.iter().enumerate() {
             const OFFSET: usize = 65;
             buf.add(i * OFFSET).write_cstring(s)?;

--- a/linux-syscall/src/misc.rs
+++ b/linux-syscall/src/misc.rs
@@ -4,6 +4,8 @@ use bitflags::bitflags;
 
 impl Syscall<'_> {
     #[cfg(target_arch = "x86_64")]
+    /// set architecture-specific thread state
+    /// for x86_64 currently
     pub fn sys_arch_prctl(&mut self, code: i32, addr: usize) -> SysResult {
         const ARCH_SET_FS: i32 = 0x1002;
         match code {
@@ -16,6 +18,7 @@ impl Syscall<'_> {
         }
     }
 
+    /// get name and information about current kernel
     pub fn sys_uname(&self, buf: UserOutPtr<u8>) -> SysResult {
         info!("uname: buf={:?}", buf);
 
@@ -27,6 +30,12 @@ impl Syscall<'_> {
         Ok(0)
     }
 
+    /// provides a method for waiting until a certain condition becomes true.
+    /// - `uaddr` - points to the futex word.
+    /// - `op` -  the operation to perform on the futex
+    /// - `val` -  a value whose meaning and purpose depends on op
+    /// - `timeout` - not support now
+    /// TODO: support timeout
     pub async fn sys_futex(
         &self,
         uaddr: usize,
@@ -34,13 +43,6 @@ impl Syscall<'_> {
         val: i32,
         timeout: UserInPtr<TimeSpec>,
     ) -> SysResult {
-        bitflags! {
-            struct FutexFlags: u32 {
-                const WAIT      = 0;
-                const WAKE      = 1;
-                const PRIVATE   = 0x80;
-            }
-        }
         let op = FutexFlags::from_bits_truncate(op);
         info!(
             "futex: uaddr: {:#x}, op: {:?}, val: {}, timeout_ptr: {:?}",
@@ -69,5 +71,19 @@ impl Syscall<'_> {
                 Err(LxError::ENOSYS)
             }
         }
+    }
+}
+
+bitflags! {
+    /// for op argument in futex()
+    struct FutexFlags: u32 {
+        /// tests that the value at the futex word pointed
+        /// to by the address uaddr still contains the expected value val,
+        /// and if so, then sleeps waiting for a FUTEX_WAKE operation on the futex word.
+        const WAIT      = 0;
+        /// wakes at most val of the waiters that are waiting on the futex word at the address uaddr.
+        const WAKE      = 1;
+        /// can be employed with all futex operations, tells the kernel that the futex is process-private and not shared with another process
+        const PRIVATE   = 0x80;
     }
 }

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -1,4 +1,13 @@
 //! Syscalls for process
+//!
+//! - fork
+//! - vfork
+//! - clone
+//! - wait4
+//! - execve
+//! - gettid
+//! - getpid
+//! - getppid
 
 use super::*;
 use bitflags::bitflags;
@@ -255,6 +264,8 @@ impl Syscall<'_> {
     //        Ok(0)
     //    }
 
+    /// set pointer to thread ID
+    /// returns the caller's thread ID
     pub fn sys_set_tid_address(&self, tidptr: UserOutPtr<i32>) -> SysResult {
         info!("set_tid_address: {:?}", tidptr);
         self.thread.set_tid_address(tidptr);
@@ -265,29 +276,53 @@ impl Syscall<'_> {
 
 bitflags! {
     pub struct CloneFlags: usize {
+        ///
         const CSIGNAL =         0xff;
+        /// the calling process and the child process run in the same memory space
         const VM =              1 << 8;
+        /// the caller and the child process share the same filesystem information
         const FS =              1 << 9;
+        /// the calling process and the child process share the same file descriptor table
         const FILES =           1 << 10;
+        /// the calling process and the child process share the same table of signal handlers.
         const SIGHAND =         1 << 11;
+        /// the calling process is being traced
         const PTRACE =          1 << 13;
+        /// the execution of the calling process is suspended until the child releases its virtual memory resources
         const VFORK =           1 << 14;
+        /// the parent of the new child will be the same as that of the call‐ing process.
         const PARENT =          1 << 15;
+        /// the child is placed in the same thread group as the calling process.
         const THREAD =          1 << 16;
+        /// cloned child is started in a new mount namespace
         const NEWNS	=           1 << 17;
+        /// the child and the calling process share a single list of System V semaphore adjustment values.
         const SYSVSEM =         1 << 18;
+        /// architecture dependent, The TLS (Thread Local Storage) descriptor is set to tls.
         const SETTLS =          1 << 19;
+        /// Store the child thread ID at the location in the parent's memory.
         const PARENT_SETTID =   1 << 20;
+        /// Clear (zero) the child thread ID
         const CHILD_CLEARTID =  1 << 21;
+        /// the parent not to receive a signal when the child terminated
         const DETACHED =        1 << 22;
+        /// a tracing process cannot force CLONE_PTRACE on this child process.
         const UNTRACED =        1 << 23;
+        /// Store the child thread ID
         const CHILD_SETTID =    1 << 24;
+        /// Create the process in a new cgroup namespace.
         const NEWCGROUP =       1 << 25;
+        /// create the process in a new UTS namespace
         const NEWUTS =          1 << 26;
+        /// create the process in a new IPC namespace.
         const NEWIPC =          1 << 27;
+        /// create the process in a new user namespace
         const NEWUSER =         1 << 28;
+        /// create the process in a new PID namespace
         const NEWPID =          1 << 29;
+        /// create the process in a new net‐work namespace.
         const NEWNET =          1 << 30;
+        /// the new process shares an I/O context with the calling process.
         const IO =              1 << 31;
     }
 }

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -27,6 +27,7 @@ impl Syscall<'_> {
         Ok(new_proc.id() as usize)
     }
 
+    /// creates a child process of the calling process, similar to fork but wait for execve
     pub async fn sys_vfork(&self) -> SysResult {
         info!("vfork:");
         let new_proc = Process::fork_from(self.zircon_process(), true)?;

--- a/linux-syscall/src/time.rs
+++ b/linux-syscall/src/time.rs
@@ -8,13 +8,15 @@ use linux_object::error::SysResult;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TimeSpec {
-    /// second
+    /// seconds
     sec: usize,
-    /// nano second
+    /// nano seconds
     nsec: usize,
 }
 
 impl Syscall<'_> {
+    /// finds the resolution (precision) of the specified clock clockid, and,
+    /// if buffer is non-NULL, stores it in the struct timespec pointed to by buffer
     pub fn sys_clock_gettime(&self, clock: usize, mut buf: UserOutPtr<TimeSpec>) -> SysResult {
         info!("clock_gettime: id={:?} buf={:?}", clock, buf);
 

--- a/linux-syscall/src/time.rs
+++ b/linux-syscall/src/time.rs
@@ -1,4 +1,5 @@
-//use super::*;
+//! Syscalls for time
+//! - clock_gettime
 
 use crate::Syscall;
 use kernel_hal::{timer_now, user::UserOutPtr};
@@ -7,7 +8,9 @@ use linux_object::error::SysResult;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TimeSpec {
+    /// second
     sec: usize,
+    /// nano second
     nsec: usize,
 }
 


### PR DESCRIPTION
 `linux-syscall`  passes `#![deny(missing_docs)]`.

reference: 

- system reference manuals section 2: System calls

fix #26 : [The "uname" command shows up incorrect results](https://github.com/rcore-os/zCore/issues/26)