### PR TITLE
Improve doc and add some simple trivial test in `linux-loader`

### DIFF
--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -1,4 +1,5 @@
 //! Linux LibOS
+//! - run process and manage trap/interrupt/syscall
 #![no_std]
 #![feature(asm)]
 #![feature(global_asm)]
@@ -44,7 +45,14 @@ pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) ->
     proc
 }
 
-/// Handle trap/interrupt/syscall
+/// Run and Manage thread
+///
+/// loop:
+/// - wait for the thread to be ready
+/// - get user thread context
+/// - enter user mode
+/// - handle trap/interrupt/syscall according to the return value
+/// - return the context to the user thread
 fn spawn(thread: Arc<Thread>) {
     let vmtoken = thread.proc().vmar().table_phys();
     let future = async move {

--- a/linux-loader/src/main.rs
+++ b/linux-loader/src/main.rs
@@ -57,7 +57,8 @@ mod tests {
         kernel_hal_unix::init();
 
         let args: Vec<String> = cmdline.split(' ').map(|s| s.into()).collect();
-        let envs = vec![]; // TODO
+        let envs =
+            vec!["PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/x86_64-alpine-linux-musl/bin".into()]; // TODO
         let hostfs = HostFS::new("../rootfs");
         let proc = run(args, envs, hostfs);
         let proc: Arc<dyn KernelObject> = proc;
@@ -65,13 +66,13 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_busybox_uname() {
-        test("/bin/busybox uname -a").await;
+    async fn test_busybox() {
+        test("/bin/busybox").await;
     }
 
     #[async_std::test]
-    async fn test_ls() {
-        test("/bin/busybox ls -a").await;
+    async fn test_uname() {
+        test("/bin/busybox uname -a").await;
     }
 
     #[async_std::test]
@@ -80,8 +81,37 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_createfile() {
+    async fn test_dir() {
+        test("/bin/busybox pwd").await;
+        test("/bin/busybox ls -a").await;
+        test("/bin/busybox dirname /bin/busybox").await;
+    }
+
+    #[async_std::test]
+    async fn test_create_remove_dir() {
         test("/bin/busybox mkdir test").await;
-        test("/bin/busybox touch test1").await;
+        test("/bin/busybox rmdir test").await;
+    }
+
+    #[async_std::test]
+    async fn test_readfile() {
+        test("/bin/busybox cat /etc/profile").await;
+    }
+
+    #[async_std::test]
+    async fn test_cp_mv() {
+        test("/bin/busybox cp /etc/hostname /etc/hostname.bak").await;
+        test("/bin/busybox mv /etc/hostname.bak /etc/hostname.mv").await;
+    }
+
+    #[async_std::test]
+    async fn test_link() {
+        test("/bin/busybox ln /etc/hostname /etc/hostname.ln").await;
+        test("/bin/busybox unlink /etc/hostname.ln").await;
+    }
+
+    #[async_std::test]
+    async fn test_env() {
+        test("/bin/busybox env").await;
     }
 }

--- a/linux-loader/src/main.rs
+++ b/linux-loader/src/main.rs
@@ -1,4 +1,5 @@
-#![deny(warnings, unused_must_use)]
+//! Linux LibOS entrance
+#![deny(warnings, unused_must_use, missing_docs)]
 #![feature(thread_id_value)]
 
 extern crate log;
@@ -9,11 +10,14 @@ use std::io::Write;
 use std::sync::Arc;
 use zircon_object::object::*;
 
+/// main entry
 #[async_std::main]
 async fn main() {
+    // init loggger for debug
     init_logger();
+    // init HAL implementation on unix
     kernel_hal_unix::init();
-
+    // run first process
     let args: Vec<_> = std::env::args().skip(1).collect();
     let envs = vec!["PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/x86_64-alpine-linux-musl/bin".into()];
 
@@ -22,6 +26,7 @@ async fn main() {
     proc.wait_signal(Signal::PROCESS_TERMINATED).await;
 }
 
+/// init the env_logger
 fn init_logger() {
     env_logger::builder()
         .format(|buf, record| {
@@ -47,6 +52,7 @@ fn init_logger() {
 mod tests {
     use super::*;
 
+    /// test with cmd line
     async fn test(cmdline: &str) {
         kernel_hal_unix::init();
 
@@ -59,7 +65,23 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn busybox() {
-        test("/bin/busybox").await;
+    async fn test_busybox_uname() {
+        test("/bin/busybox uname -a").await;
+    }
+
+    #[async_std::test]
+    async fn test_ls() {
+        test("/bin/busybox ls -a").await;
+    }
+
+    #[async_std::test]
+    async fn test_date() {
+        test("/bin/busybox date").await;
+    }
+
+    #[async_std::test]
+    async fn test_createfile() {
+        test("/bin/busybox mkdir test").await;
+        test("/bin/busybox touch test1").await;
     }
 }


### PR DESCRIPTION
- `linux-loader` passes #![deny(missing_docs)]
- add some simple test using busybox command to improve the coverage in linux-loader:
  - fs
    - copy and remove
    - link and unlink
    - create and remove dir
    - readfile
  - date
  - mkdir

It seems most command in the busybox need more syscalls.