### PR TITLE
Refactor exception

### DIFF
--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -186,7 +186,7 @@ fn spawn(thread: Arc<Thread>) {
                 .await;
         };
         Exception::create(thread.clone(), ExceptionType::ThreadStarting, None)
-            .handle_with_exceptionates(false, Some(thread.proc().get_debug_exceptionate()), false)
+            .handle_with_exceptionates(false, Some(thread.proc().debug_exceptionate()), false)
             .await;
         loop {
             let mut cx = thread.wait_for_run().await;
@@ -270,7 +270,7 @@ fn spawn(thread: Arc<Thread>) {
         let end_exception = Exception::create(thread.clone(), ExceptionType::ThreadExiting, None);
         let handled = thread
             .proc()
-            .get_debug_exceptionate()
+            .debug_exceptionate()
             .send_exception(&end_exception);
         if let Ok(future) = handled {
             thread.dying_run(future).await.ok();

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -42,8 +42,8 @@ pub struct Images<T: AsRef<[u8]>> {
 
 pub fn run_userboot(images: &Images<impl AsRef<[u8]>>, cmdline: &str) -> Arc<Process> {
     let job = Job::root();
-    let proc = Process::create(&job, "userboot", 0).unwrap();
-    let thread = Thread::create(&proc, "userboot", 0).unwrap();
+    let proc = Process::create(&job, "userboot").unwrap();
+    let thread = Thread::create(&proc, "userboot").unwrap();
     let resource = Resource::create(
         "root",
         ResourceKind::ROOT,

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -176,37 +176,21 @@ fn spawn(thread: Arc<Thread>) {
     let vmtoken = thread.proc().vmar().table_phys();
     let future = async move {
         kernel_hal::Thread::set_tid(thread.id(), thread.proc().id());
-        let mut exit = false;
-        if thread.get_first_thread() {
-            let proc_start_exception =
-                Exception::create(thread.clone(), ExceptionType::ProcessStarting, None);
-            if !proc_start_exception
+        if thread.is_first_thread() {
+            Exception::create(thread.clone(), ExceptionType::ProcessStarting, None)
                 .handle_with_exceptionates(
                     false,
                     JobDebuggerIterator::new(thread.proc().job()),
                     true,
                 )
-                .await
-            {
-                exit = true;
-            }
+                .await;
         };
-        let start_exception =
-            Exception::create(thread.clone(), ExceptionType::ThreadStarting, None);
-        if !start_exception
+        Exception::create(thread.clone(), ExceptionType::ThreadStarting, None)
             .handle_with_exceptionates(false, Some(thread.proc().get_debug_exceptionate()), false)
-            .await
-        {
-            exit = true;
-        }
-        while !exit {
+            .await;
+        loop {
             let mut cx = thread.wait_for_run().await;
             if thread.state() == ThreadState::Dying {
-                info!(
-                    "proc={:?} thread={:?} was killed",
-                    thread.proc().name(),
-                    thread.name()
-                );
                 break;
             }
             trace!("go to user: {:#x?}", cx);
@@ -228,12 +212,12 @@ fn spawn(thread: Arc<Thread>) {
             EXCEPTIONS_USER.add(1);
             #[cfg(target_arch = "aarch64")]
             match cx.trap_num {
-                0 => exit = handle_syscall(&thread, &mut cx.general).await,
+                0 => handle_syscall(&thread, &mut cx.general).await,
                 _ => unimplemented!(),
             }
             #[cfg(target_arch = "x86_64")]
             match cx.trap_num {
-                0x100 => exit = handle_syscall(&thread, &mut cx.general).await,
+                0x100 => handle_syscall(&thread, &mut cx.general).await,
                 0x20..=0x3f => {
                     kernel_hal::InterruptManager::handle(cx.trap_num as u8);
                     if cx.trap_num == 0x20 {
@@ -252,34 +236,17 @@ fn spawn(thread: Arc<Thread>) {
                     // FIXME:
                     #[cfg(target_arch = "aarch64")]
                     let flags = MMUFlags::WRITE;
-                    error!(
-                        "page fualt from user mode {:#x} {:#x?}",
-                        kernel_hal::fetch_fault_vaddr(),
-                        flags
-                    );
-                    match thread
-                        .proc()
-                        .vmar()
-                        .handle_page_fault(kernel_hal::fetch_fault_vaddr(), flags)
-                    {
-                        Ok(()) => {}
-                        Err(e) => {
-                            error!(
-                                "proc={:?} thread={:?} err={:?}",
-                                thread.proc().name(),
-                                thread.name(),
-                                e
-                            );
-                            error!("Page Fault from user mode {:#x?}", cx);
-                            let exception = Exception::create(
-                                thread.clone(),
-                                ExceptionType::FatalPageFault,
-                                Some(&cx),
-                            );
-                            if !exception.handle(true).await {
-                                exit = true;
-                            }
-                        }
+                    let fault_vaddr = kernel_hal::fetch_fault_vaddr();
+                    error!("page fault from user mode {:#x} {:#x?}", fault_vaddr, flags);
+                    let vmar = thread.proc().vmar();
+                    if vmar.handle_page_fault(fault_vaddr, flags).is_err() {
+                        error!("Page Fault from user mode: {:#x?}", cx);
+                        let exception = Exception::create(
+                            thread.clone(),
+                            ExceptionType::FatalPageFault,
+                            Some(&cx),
+                        );
+                        exception.handle(true).await;
                     }
                 }
                 0x8 => {
@@ -293,22 +260,12 @@ fn spawn(thread: Arc<Thread>) {
                         0x17 => ExceptionType::UnalignedAccess,
                         _ => ExceptionType::General,
                     };
-                    error!("User mode exception:{:?} {:#x?}", type_, cx);
+                    error!("User mode exception: {:?} {:#x?}", type_, cx);
                     let exception = Exception::create(thread.clone(), type_, Some(&cx));
-                    if !exception.handle(true).await {
-                        exit = true;
-                    }
+                    exception.handle(true).await;
                 }
             }
             thread.end_running(cx);
-            if exit {
-                info!(
-                    "proc={:?} thread={:?} exited",
-                    thread.proc().name(),
-                    thread.name()
-                );
-                break;
-            }
         }
         let end_exception = Exception::create(thread.clone(), ExceptionType::ThreadExiting, None);
         let handled = thread
@@ -317,15 +274,13 @@ fn spawn(thread: Arc<Thread>) {
             .send_exception(&end_exception);
         if let Ok(future) = handled {
             thread.dying_run(future).await.ok();
-        } else {
-            handled.ok();
         }
         thread.terminate();
     };
     kernel_hal::Thread::spawn(Box::pin(future), vmtoken);
 }
 
-async fn handle_syscall(thread: &Arc<Thread>, regs: &mut GeneralRegs) -> bool {
+async fn handle_syscall(thread: &Arc<Thread>, regs: &mut GeneralRegs) {
     #[cfg(target_arch = "x86_64")]
     let num = regs.rax as u32;
     #[cfg(target_arch = "aarch64")]
@@ -355,7 +310,6 @@ async fn handle_syscall(thread: &Arc<Thread>, regs: &mut GeneralRegs) -> bool {
         regs,
         thread: thread.clone(),
         spawn_fn: spawn,
-        exit: false,
     };
     let ret = syscall.syscall(num, args).await as usize;
     #[cfg(target_arch = "x86_64")]
@@ -366,5 +320,4 @@ async fn handle_syscall(thread: &Arc<Thread>, regs: &mut GeneralRegs) -> bool {
     {
         syscall.regs.x0 = ret;
     }
-    syscall.exit
 }

--- a/zircon-object/src/hypervisor/vcpu.rs
+++ b/zircon-object/src/hypervisor/vcpu.rs
@@ -23,7 +23,7 @@ define_count_helper!(Vcpu);
 
 impl Vcpu {
     pub fn new(guest: Arc<Guest>, entry: u64, thread: Arc<Thread>) -> ZxResult<Arc<Self>> {
-        if thread.get_flags().contains(ThreadFlag::VCPU) {
+        if thread.flags().contains(ThreadFlag::VCPU) {
             return Err(ZxError::BAD_STATE);
         }
         let inner = Mutex::new(VcpuInner::new(entry, guest.rvm_guest())?);

--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -430,7 +430,12 @@ mod tests {
         let futex = proc.get_futex(&VALUE);
         let future = futex.wait_with_owner(1, Some(thread.clone()), Some(thread.clone()));
         let result: ZxResult = thread
-            .blocking_run(future, ThreadState::BlockedFutex, Duration::from_millis(1))
+            .blocking_run(
+                future,
+                ThreadState::BlockedFutex,
+                Duration::from_millis(1),
+                None,
+            )
             .await;
         assert_eq!(result.unwrap_err(), ZxError::TIMED_OUT);
         assert_eq!(futex.wake(1), 0);

--- a/zircon-object/src/signal/futex.rs
+++ b/zircon-object/src/signal/futex.rs
@@ -387,8 +387,8 @@ mod tests {
     #[async_std::test]
     async fn owner() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         static VALUE: AtomicI32 = AtomicI32::new(1);
         let futex = proc.get_futex(&VALUE);
@@ -423,8 +423,8 @@ mod tests {
     #[async_std::test]
     async fn time_out() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         static VALUE: AtomicI32 = AtomicI32::new(1);
         let futex = proc.get_futex(&VALUE);

--- a/zircon-object/src/task/exception.rs
+++ b/zircon-object/src/task/exception.rs
@@ -530,8 +530,8 @@ mod tests {
     fn exceptionate_iterator() {
         let parent_job = Job::root();
         let job = parent_job.create_child().unwrap();
-        let proc = Process::create(&job, "proc", 0).unwrap();
-        let thread = Thread::create(&proc, "thread", 0).unwrap();
+        let proc = Process::create(&job, "proc").unwrap();
+        let thread = Thread::create(&proc, "thread").unwrap();
 
         let exception = Exception::create(thread.clone(), ExceptionType::Synth, None);
         let iterator = ExceptionateIterator::new(&exception);
@@ -551,8 +551,8 @@ mod tests {
     fn exceptionate_iterator_second_chance() {
         let parent_job = Job::root();
         let job = parent_job.create_child().unwrap();
-        let proc = Process::create(&job, "proc", 0).unwrap();
-        let thread = Thread::create(&proc, "thread", 0).unwrap();
+        let proc = Process::create(&job, "proc").unwrap();
+        let thread = Thread::create(&proc, "thread").unwrap();
 
         let exception = Exception::create(thread.clone(), ExceptionType::Synth, None);
         exception.inner.lock().second_chance = true;
@@ -592,8 +592,8 @@ mod tests {
     async fn exception_handling() {
         let parent_job = Job::root();
         let job = parent_job.create_child().unwrap();
-        let proc = Process::create(&job, "proc", 0).unwrap();
-        let thread = Thread::create(&proc, "thread", 0).unwrap();
+        let proc = Process::create(&job, "proc").unwrap();
+        let thread = Thread::create(&proc, "thread").unwrap();
 
         let exception = Exception::create(thread.clone(), ExceptionType::Synth, None);
 

--- a/zircon-object/src/task/exception.rs
+++ b/zircon-object/src/task/exception.rs
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn exceptionate_iterator() {
         let parent_job = Job::root();
-        let job = parent_job.create_child(0).unwrap();
+        let job = parent_job.create_child().unwrap();
         let proc = Process::create(&job, "proc", 0).unwrap();
         let thread = Thread::create(&proc, "thread", 0).unwrap();
 
@@ -559,7 +559,7 @@ mod tests {
     #[test]
     fn exceptionate_iterator_second_chance() {
         let parent_job = Job::root();
-        let job = parent_job.create_child(0).unwrap();
+        let job = parent_job.create_child().unwrap();
         let proc = Process::create(&job, "proc", 0).unwrap();
         let thread = Thread::create(&proc, "thread", 0).unwrap();
 
@@ -582,9 +582,9 @@ mod tests {
     #[test]
     fn job_debugger_iterator() {
         let parent_job = Job::root();
-        let job = parent_job.create_child(0).unwrap();
-        let child_job = job.create_child(0).unwrap();
-        let _grandson_job = child_job.create_child(0).unwrap();
+        let job = parent_job.create_child().unwrap();
+        let child_job = job.create_child().unwrap();
+        let _grandson_job = child_job.create_child().unwrap();
 
         let iterator = JobDebuggerIterator::new(child_job.clone());
         let expected = [
@@ -600,7 +600,7 @@ mod tests {
     #[async_std::test]
     async fn exception_handling() {
         let parent_job = Job::root();
-        let job = parent_job.create_child(0).unwrap();
+        let job = parent_job.create_child().unwrap();
         let proc = Process::create(&job, "proc", 0).unwrap();
         let thread = Thread::create(&proc, "thread", 0).unwrap();
 

--- a/zircon-object/src/task/exception.rs
+++ b/zircon-object/src/task/exception.rs
@@ -511,7 +511,7 @@ mod tests {
         let thread = Thread::create(&proc, "thread").unwrap();
 
         let exception = Exception::create(&thread, ExceptionType::Synth, None);
-        let iterator = ExceptionateIterator::new(&exception);
+        let actual: Vec<_> = ExceptionateIterator::new(&exception).collect();
         let expected = [
             proc.debug_exceptionate(),
             thread.exceptionate(),
@@ -519,7 +519,8 @@ mod tests {
             job.exceptionate(),
             parent_job.exceptionate(),
         ];
-        for (actual, expected) in iterator.zip(expected.iter()) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
             assert!(Arc::ptr_eq(&actual, expected));
         }
     }
@@ -533,7 +534,7 @@ mod tests {
 
         let exception = Exception::create(&thread, ExceptionType::Synth, None);
         exception.inner.lock().second_chance = true;
-        let iterator = ExceptionateIterator::new(&exception);
+        let actual: Vec<_> = ExceptionateIterator::new(&exception).collect();
         let expected = [
             proc.debug_exceptionate(),
             thread.exceptionate(),
@@ -542,7 +543,8 @@ mod tests {
             job.exceptionate(),
             parent_job.exceptionate(),
         ];
-        for (actual, expected) in iterator.zip(expected.iter()) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
             assert!(Arc::ptr_eq(&actual, expected));
         }
     }
@@ -554,13 +556,14 @@ mod tests {
         let child_job = job.create_child().unwrap();
         let _grandson_job = child_job.create_child().unwrap();
 
-        let iterator = JobDebuggerIterator::new(child_job.clone());
+        let actual: Vec<_> = JobDebuggerIterator::new(child_job.clone()).collect();
         let expected = [
             child_job.debug_exceptionate(),
             job.debug_exceptionate(),
             parent_job.debug_exceptionate(),
         ];
-        for (actual, expected) in iterator.zip(expected.iter()) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
             assert!(Arc::ptr_eq(&actual, expected));
         }
     }

--- a/zircon-object/src/task/job.rs
+++ b/zircon-object/src/task/job.rs
@@ -393,7 +393,7 @@ mod tests {
     fn parent_child() {
         let root_job = Job::root();
         let job = Job::create_child(&root_job).expect("failed to create job");
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
 
         assert_eq!(root_job.get_child(job.id()).unwrap().id(), job.id());
         assert_eq!(root_job.get_child(proc.id()).unwrap().id(), proc.id());
@@ -404,7 +404,7 @@ mod tests {
         assert!(Arc::ptr_eq(&job.parent().unwrap(), &root_job));
 
         let job1 = root_job.create_child().expect("failed to create job");
-        let proc1 = Process::create(&root_job, "proc1", 0).expect("failed to create process");
+        let proc1 = Process::create(&root_job, "proc1").expect("failed to create process");
         assert_eq!(root_job.children_ids(), vec![job.id(), job1.id()]);
         assert_eq!(root_job.process_ids(), vec![proc.id(), proc1.id()]);
 
@@ -423,7 +423,7 @@ mod tests {
         assert!(!root_job.is_empty());
         assert!(job.is_empty());
 
-        let _proc = Process::create(&job, "proc", 0).expect("failed to create process");
+        let _proc = Process::create(&job, "proc").expect("failed to create process");
         assert!(!job.is_empty());
     }
 
@@ -431,8 +431,8 @@ mod tests {
     fn kill() {
         let root_job = Job::root();
         let job = Job::create_child(&root_job).expect("failed to create job");
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         root_job.kill();
         assert!(root_job.inner.lock().killed);
@@ -465,7 +465,7 @@ mod tests {
         // The job's process have no threads.
         let root_job = Job::root();
         let job = Job::create_child(&root_job).expect("failed to create job");
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
         root_job.kill();
         assert!(root_job.inner.lock().killed);
         assert!(job.inner.lock().killed);
@@ -481,7 +481,7 @@ mod tests {
         let job = root_job.create_child().unwrap();
         let job1 = root_job.create_child().unwrap();
 
-        let proc = Process::create(&job, "proc", 0).expect("failed to create process");
+        let proc = Process::create(&job, "proc").expect("failed to create process");
 
         assert_eq!(
             proc.set_critical_at_job(&job1, true).err(),

--- a/zircon-object/src/task/job.rs
+++ b/zircon-object/src/task/job.rs
@@ -85,8 +85,7 @@ impl Job {
     }
 
     /// Create a new child job object.
-    pub fn create_child(self: &Arc<Self>, _options: u32) -> ZxResult<Arc<Self>> {
-        // TODO: options
+    pub fn create_child(self: &Arc<Self>) -> ZxResult<Arc<Self>> {
         let mut inner = self.inner.lock();
         if inner.killed {
             return Err(ZxError::BAD_STATE);
@@ -298,14 +297,14 @@ mod tests {
     fn create() {
         let root_job = Job::root();
         let job: Arc<dyn KernelObject> =
-            Job::create_child(&root_job, 0).expect("failed to create job");
+            Job::create_child(&root_job).expect("failed to create job");
 
         assert!(Arc::ptr_eq(&root_job.get_child(job.id()).unwrap(), &job));
         assert_eq!(job.related_koid(), root_job.id());
         assert_eq!(root_job.related_koid(), 0);
 
         root_job.kill();
-        assert_eq!(root_job.create_child(0).err(), Some(ZxError::BAD_STATE));
+        assert_eq!(root_job.create_child().err(), Some(ZxError::BAD_STATE));
     }
 
     #[test]
@@ -345,7 +344,7 @@ mod tests {
         );
 
         // create a child job
-        let job = Job::create_child(&root_job, 0).expect("failed to create job");
+        let job = Job::create_child(&root_job).expect("failed to create job");
 
         // should inherit parent's policy.
         assert_eq!(
@@ -393,7 +392,7 @@ mod tests {
     #[test]
     fn parent_child() {
         let root_job = Job::root();
-        let job = Job::create_child(&root_job, 0).expect("failed to create job");
+        let job = Job::create_child(&root_job).expect("failed to create job");
         let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
 
         assert_eq!(root_job.get_child(job.id()).unwrap().id(), job.id());
@@ -404,20 +403,20 @@ mod tests {
         );
         assert!(Arc::ptr_eq(&job.parent().unwrap(), &root_job));
 
-        let job1 = root_job.create_child(0).expect("failed to create job");
+        let job1 = root_job.create_child().expect("failed to create job");
         let proc1 = Process::create(&root_job, "proc1", 0).expect("failed to create process");
         assert_eq!(root_job.children_ids(), vec![job.id(), job1.id()]);
         assert_eq!(root_job.process_ids(), vec![proc.id(), proc1.id()]);
 
         root_job.kill();
-        assert_eq!(root_job.create_child(0).err(), Some(ZxError::BAD_STATE));
+        assert_eq!(root_job.create_child().err(), Some(ZxError::BAD_STATE));
     }
 
     #[test]
     fn check() {
         let root_job = Job::root();
         assert!(root_job.is_empty());
-        let job = root_job.create_child(0).expect("failed to create job");
+        let job = root_job.create_child().expect("failed to create job");
         assert_eq!(root_job.check_root_job(), Ok(()));
         assert_eq!(job.check_root_job(), Err(ZxError::ACCESS_DENIED));
 
@@ -431,7 +430,7 @@ mod tests {
     #[test]
     fn kill() {
         let root_job = Job::root();
-        let job = Job::create_child(&root_job, 0).expect("failed to create job");
+        let job = Job::create_child(&root_job).expect("failed to create job");
         let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
         let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
 
@@ -465,7 +464,7 @@ mod tests {
 
         // The job's process have no threads.
         let root_job = Job::root();
-        let job = Job::create_child(&root_job, 0).expect("failed to create job");
+        let job = Job::create_child(&root_job).expect("failed to create job");
         let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
         root_job.kill();
         assert!(root_job.inner.lock().killed);
@@ -479,8 +478,8 @@ mod tests {
     #[test]
     fn critical_process() {
         let root_job = Job::root();
-        let job = root_job.create_child(0).unwrap();
-        let job1 = root_job.create_child(0).unwrap();
+        let job = root_job.create_child().unwrap();
+        let job1 = root_job.create_child().unwrap();
 
         let proc = Process::create(&job, "proc", 0).expect("failed to create process");
 

--- a/zircon-object/src/task/mod.rs
+++ b/zircon-object/src/task/mod.rs
@@ -2,6 +2,7 @@
 //! Objects for Task Management.
 
 use super::*;
+use alloc::sync::Arc;
 
 mod exception;
 mod job;
@@ -26,6 +27,12 @@ pub trait Task: Sync + Send {
 
     /// Resume the task
     fn resume(&self);
+
+    /// Get the exceptionate.
+    fn exceptionate(&self) -> Arc<Exceptionate>;
+
+    /// Get the debug exceptionate.
+    fn debug_exceptionate(&self) -> Arc<Exceptionate>;
 }
 
 /// The return code set when a task is killed via zx_task_kill().

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -159,7 +159,7 @@ impl Process {
             inner.status = Status::Running;
             handle_value = arg1.map_or(INVALID_HANDLE, |handle| inner.add_handle(handle));
         }
-        thread.set_first_thread(true);
+        thread.set_first_thread();
         match thread.start(entry, stack, handle_value as usize, arg2, spawn_fn) {
             Ok(_) => Ok(()),
             Err(err) => {

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -782,7 +782,7 @@ mod tests {
             Some(ZxError::ACCESS_DENIED)
         );
 
-        let _job = root_job.create_child(0).unwrap();
+        let _job = root_job.create_child().unwrap();
         assert_eq!(
             root_job
                 .set_policy_basic(SetPolicyOptions::Absolute, &[policy1, policy2])

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -492,16 +492,6 @@ impl Process {
         self.inner.lock().get_cancel_token(handle_value)
     }
 
-    /// Get the exceptionate of this process.
-    pub fn get_exceptionate(&self) -> Arc<Exceptionate> {
-        self.exceptionate.clone()
-    }
-
-    /// Get the debug exceptionate of this process.
-    pub fn get_debug_exceptionate(&self) -> Arc<Exceptionate> {
-        self.debug_exceptionate.clone()
-    }
-
     /// Get KoIDs of Threads.
     pub fn thread_ids(&self) -> Vec<KoID> {
         self.inner.lock().threads.iter().map(|t| t.id()).collect()
@@ -525,6 +515,14 @@ impl Task for Process {
         for thread in inner.threads.iter() {
             thread.resume();
         }
+    }
+
+    fn exceptionate(&self) -> Arc<Exceptionate> {
+        self.exceptionate.clone()
+    }
+
+    fn debug_exceptionate(&self) -> Arc<Exceptionate> {
+        self.debug_exceptionate.clone()
     }
 }
 

--- a/zircon-object/src/task/thread.rs
+++ b/zircon-object/src/task/thread.rs
@@ -170,7 +170,7 @@ bitflags! {
 
 impl Thread {
     /// Create a new thread.
-    pub fn create(proc: &Arc<Process>, name: &str, _options: u32) -> ZxResult<Arc<Self>> {
+    pub fn create(proc: &Arc<Process>, name: &str) -> ZxResult<Arc<Self>> {
         Self::create_with_ext(proc, name, ())
     }
 
@@ -180,7 +180,6 @@ impl Thread {
         name: &str,
         ext: impl Any + Send + Sync,
     ) -> ZxResult<Arc<Self>> {
-        // TODO: options
         let thread = Arc::new(Thread {
             base: KObjectBase::with_name(name),
             _counter: CountHelper::new(),
@@ -630,8 +629,8 @@ mod tests {
     #[test]
     fn create() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
         assert_eq!(thread.get_flags(), ThreadFlag::empty());
 
         let thread: Arc<dyn KernelObject> = thread;
@@ -643,9 +642,9 @@ mod tests {
     #[ignore]
     fn start() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
-        let thread1 = Thread::create(&proc, "thread1", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
+        let thread1 = Thread::create(&proc, "thread1").expect("failed to create thread");
 
         // allocate stack for new thread
         let mut stack = vec![0u8; 0x1000];
@@ -707,8 +706,8 @@ mod tests {
     #[async_std::test]
     async fn blocking_run() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         let handle = Handle::new(proc.clone(), Rights::DEFAULT_PROCESS);
         let handle_value = proc.add_handle(handle);
@@ -753,8 +752,8 @@ mod tests {
     #[test]
     fn info() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         let info = thread.get_thread_info();
         assert!(info.state == thread.state() as u32 && info.wait_exception_channel_type == 0);
@@ -767,8 +766,8 @@ mod tests {
     #[test]
     fn read_write_state() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         let mut buf = [0; 10];
         assert_eq!(
@@ -792,8 +791,8 @@ mod tests {
     #[test]
     fn ext() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         let _ext = thread.ext();
         // TODO
@@ -802,8 +801,8 @@ mod tests {
     #[async_std::test]
     async fn wait_for_run() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         // without suspend
         let context = thread.wait_for_run().await;
@@ -830,8 +829,8 @@ mod tests {
     #[test]
     fn time() {
         let root_job = Job::root();
-        let proc = Process::create(&root_job, "proc", 0).expect("failed to create process");
-        let thread = Thread::create(&proc, "thread", 0).expect("failed to create thread");
+        let proc = Process::create(&root_job, "proc").expect("failed to create process");
+        let thread = Thread::create(&proc, "thread").expect("failed to create thread");
 
         assert_eq!(thread.get_time(), 0);
         thread.time_add(10);

--- a/zircon-syscall/src/channel.rs
+++ b/zircon-syscall/src/channel.rs
@@ -176,7 +176,7 @@ impl Syscall<'_> {
         pin_mut!(future);
         let rd_msg: MessagePacket = self
             .thread
-            .blocking_run(future, ThreadState::BlockedChannel, deadline.into())
+            .blocking_run(future, ThreadState::BlockedChannel, deadline.into(), None)
             .await?;
 
         actual_bytes.write(rd_msg.data.len() as u32)?;

--- a/zircon-syscall/src/ddk.rs
+++ b/zircon-syscall/src/ddk.rs
@@ -261,6 +261,7 @@ impl Syscall<'_> {
                 future,
                 ThreadState::BlockedInterrupt,
                 Deadline::forever().into(),
+                None,
             )
             .await?;
         out.write_if_not_null(timestamp)?;

--- a/zircon-syscall/src/exception.rs
+++ b/zircon-syscall/src/exception.rs
@@ -25,20 +25,20 @@ impl Syscall<'_> {
                 return Err(ZxError::ACCESS_DENIED);
             }
             match option {
-                ExceptionChannelOption::None => job.get_exceptionate(),
-                ExceptionChannelOption::Debugger => job.get_debug_exceptionate(),
+                ExceptionChannelOption::None => job.exceptionate(),
+                ExceptionChannelOption::Debugger => job.debug_exceptionate(),
             }
         } else if let Ok(process) = task.clone().downcast_arc::<Process>() {
             if !rights.contains(Rights::ENUMERATE) {
                 return Err(ZxError::ACCESS_DENIED);
             }
             match option {
-                ExceptionChannelOption::None => process.get_exceptionate(),
-                ExceptionChannelOption::Debugger => process.get_debug_exceptionate(),
+                ExceptionChannelOption::None => process.exceptionate(),
+                ExceptionChannelOption::Debugger => process.debug_exceptionate(),
             }
         } else if let Ok(thread) = task.clone().downcast_arc::<Thread>() {
             match option {
-                ExceptionChannelOption::None => thread.get_exceptionate(),
+                ExceptionChannelOption::None => thread.exceptionate(),
                 ExceptionChannelOption::Debugger => return Err(ZxError::INVALID_ARGS),
             }
         } else {

--- a/zircon-syscall/src/exception.rs
+++ b/zircon-syscall/src/exception.rs
@@ -67,7 +67,7 @@ impl Syscall<'_> {
         let proc = self.thread.proc();
         let exception =
             proc.get_object_with_rights::<ExceptionObject>(exception, Rights::default())?;
-        let (object, right) = exception.get_exception().get_thread_and_rights();
+        let (object, right) = exception.get_thread_and_rights();
         let handle = proc.add_handle(Handle::new(object, right));
         out.write(handle)?;
         Ok(())
@@ -87,10 +87,10 @@ impl Syscall<'_> {
         let proc = self.thread.proc();
         let exception =
             proc.get_object_with_rights::<ExceptionObject>(exception, Rights::default())?;
-        if exception.get_exception().get_current_channel_type() == ExceptionChannelType::Thread {
+        if exception.current_channel_type() == ExceptionChannelType::Thread {
             return Err(ZxError::ACCESS_DENIED);
         }
-        let (object, right) = exception.get_exception().get_process_and_rights();
+        let (object, right) = exception.get_process_and_rights();
         let handle = proc.add_handle(Handle::new(object, right));
         out.write(handle)?;
         Ok(())

--- a/zircon-syscall/src/futex.rs
+++ b/zircon-syscall/src/futex.rs
@@ -29,7 +29,7 @@ impl Syscall<'_> {
         };
         let future = futex.wait_with_owner(current_value, Some(self.thread.clone()), new_owner);
         self.thread
-            .blocking_run(future, ThreadState::BlockedFutex, deadline.into())
+            .blocking_run(future, ThreadState::BlockedFutex, deadline.into(), None)
             .await?;
         Ok(())
     }

--- a/zircon-syscall/src/lib.rs
+++ b/zircon-syscall/src/lib.rs
@@ -53,7 +53,6 @@ pub struct Syscall<'a> {
     pub regs: &'a mut GeneralRegs,
     pub thread: Arc<Thread>,
     pub spawn_fn: fn(thread: Arc<Thread>),
-    pub exit: bool,
 }
 
 impl Syscall<'_> {
@@ -379,11 +378,6 @@ impl Syscall<'_> {
             }
         };
         info!("{}|{} {:?} <= {:?}", proc_name, thread_name, sys_type, ret);
-        if ret == Err(ZxError::STOP) && !self.exit {
-            // This is an error that only happens when the thread was killed during a blocking syscall
-            info!("{}|{}  KILLED WHEN BLOCKING", proc_name, thread_name);
-            self.exit = true
-        }
         match ret {
             Ok(_) => 0,
             Err(err) => err as isize,

--- a/zircon-syscall/src/object.rs
+++ b/zircon-syscall/src/object.rs
@@ -88,18 +88,16 @@ impl Syscall<'_> {
                 let mut info_ptr = UserOutPtr::<u32>::from_addr_size(buffer, buffer_size)?;
                 let state = proc
                     .get_object_with_rights::<ExceptionObject>(handle_value, Rights::GET_PROPERTY)?
-                    .get_exception()
-                    .get_state();
+                    .state();
                 info_ptr.write(state)?;
                 Ok(())
             }
             Property::ExceptionStrategy => {
                 let mut info_ptr = UserOutPtr::<u32>::from_addr_size(buffer, buffer_size)?;
-                let state = proc
+                let strategy = proc
                     .get_object_with_rights::<ExceptionObject>(handle_value, Rights::GET_PROPERTY)?
-                    .get_exception()
-                    .get_strategy();
-                info_ptr.write(state)?;
+                    .strategy();
+                info_ptr.write(strategy)?;
                 Ok(())
             }
             _ => {
@@ -170,15 +168,13 @@ impl Syscall<'_> {
             Property::ExceptionState => {
                 let state = UserInPtr::<u32>::from_addr_size(buffer, buffer_size)?.read()?;
                 proc.get_object_with_rights::<ExceptionObject>(handle_value, Rights::SET_PROPERTY)?
-                    .get_exception()
                     .set_state(state)?;
                 Ok(())
             }
             Property::ExceptionStrategy => {
-                let state = UserInPtr::<u32>::from_addr_size(buffer, buffer_size)?.read()?;
+                let strategy = UserInPtr::<u32>::from_addr_size(buffer, buffer_size)?.read()?;
                 proc.get_object_with_rights::<ExceptionObject>(handle_value, Rights::SET_PROPERTY)?
-                    .get_exception()
-                    .set_strategy(state)?;
+                    .set_strategy(strategy)?;
                 Ok(())
             }
             _ => {

--- a/zircon-syscall/src/object.rs
+++ b/zircon-syscall/src/object.rs
@@ -203,11 +203,11 @@ impl Syscall<'_> {
         let future = object.wait_signal(signals);
         let signal = self
             .thread
-            .cancelable_blocking_run(
+            .blocking_run(
                 future,
                 ThreadState::BlockedWaitOne,
                 deadline.into(),
-                cancel_token,
+                Some(cancel_token),
             )
             .await
             .or_else(|e| {
@@ -449,7 +449,7 @@ impl Syscall<'_> {
         let future = wait_signal_many(&waiters);
         let res = self
             .thread
-            .blocking_run(future, ThreadState::BlockedWaitMany, deadline.into())
+            .blocking_run(future, ThreadState::BlockedWaitMany, deadline.into(), None)
             .await?;
         for (i, item) in items.iter_mut().enumerate() {
             item.observed = res[i];

--- a/zircon-syscall/src/port.rs
+++ b/zircon-syscall/src/port.rs
@@ -31,7 +31,7 @@ impl Syscall<'_> {
         pin_mut!(future);
         let packet = self
             .thread
-            .blocking_run(future, ThreadState::BlockedPort, deadline.into())
+            .blocking_run(future, ThreadState::BlockedPort, deadline.into(), None)
             .await?;
         packet_res.write(packet)?;
         Ok(())

--- a/zircon-syscall/src/task.rs
+++ b/zircon-syscall/src/task.rs
@@ -262,7 +262,7 @@ impl Syscall<'_> {
             let parent_job = proc
                 .get_object_with_rights::<Job>(parent, Rights::MANAGE_JOB)
                 .or_else(|_| proc.get_object_with_rights::<Job>(parent, Rights::WRITE))?;
-            let child = parent_job.create_child(options)?;
+            let child = parent_job.create_child()?;
             out.write(proc.add_handle(Handle::new(child, Rights::DEFAULT_JOB)))?;
             Ok(())
         }

--- a/zircon-syscall/src/task.rs
+++ b/zircon-syscall/src/task.rs
@@ -40,7 +40,6 @@ impl Syscall<'_> {
         info!("proc.exit: code={:?}", code);
         let proc = self.thread.proc();
         proc.exit(code);
-        self.exit = true;
         Ok(())
     }
 
@@ -180,7 +179,6 @@ impl Syscall<'_> {
     pub fn sys_thread_exit(&mut self) -> ZxResult {
         info!("thread.exit:");
         self.thread.exit();
-        self.exit = true;
         Ok(())
     }
 
@@ -222,21 +220,8 @@ impl Syscall<'_> {
             job.kill();
         } else if let Ok(process) = proc.get_object_with_rights::<Process>(handle, Rights::DESTROY)
         {
-            if Arc::ptr_eq(&process, &proc) {
-                //self kill, exit
-                self.exit = true;
-            }
             process.kill();
         } else if let Ok(thread) = proc.get_object_with_rights::<Thread>(handle, Rights::DESTROY) {
-            info!(
-                "killing thread: proc={:?} thread={:?}",
-                thread.proc().name(),
-                thread.name()
-            );
-            if Arc::ptr_eq(&thread, &self.thread) {
-                //self kill, exit
-                self.exit = true;
-            }
             thread.kill();
         } else {
             return Err(ZxError::WRONG_TYPE);

--- a/zircon-syscall/src/time.rs
+++ b/zircon-syscall/src/time.rs
@@ -100,7 +100,8 @@ impl Syscall<'_> {
                 .blocking_run(
                     sleep_until(deadline.into()),
                     ThreadState::BlockedSleeping,
-                    Duration::from_nanos(u64::max_value()),
+                    Deadline::forever().into(),
+                    None,
                 )
                 .await?;
         }


### PR DESCRIPTION
* Make things private as much as possible.
* Rustify method names: omit `get`.
* Convert `ExceptionateInner` into a state machine.
* Merge `cancelable_blocking_run` to `blocking_run`.
* Remove `exit` field from `Syscall` struct. Use thread state instead.
* Remove reserved options of `Job`, `Process`, `Thread` object.

@benpigchu Please take a look.