### PR TITLE
Refactor thread

### DIFF
--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -11,6 +11,7 @@ extern crate log;
 
 use {
     alloc::{boxed::Box, string::String, sync::Arc, vec::Vec},
+    core::{future::Future, pin::Pin},
     kernel_hal::{GeneralRegs, MMUFlags},
     linux_object::{
         fs::{vfs::FileSystem, INodeExt},
@@ -40,12 +41,12 @@ pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) ->
     let (entry, sp) = loader.load(&proc.vmar(), &data, args, envs).unwrap();
 
     thread
-        .start(entry, sp, 0, 0, spawn)
+        .start(entry, sp, 0, 0, thread_fn)
         .expect("failed to start main thread");
     proc
 }
 
-/// Run and Manage thread
+/// The function of a new thread.
 ///
 /// loop:
 /// - wait for the thread to be ready
@@ -53,55 +54,54 @@ pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) ->
 /// - enter user mode
 /// - handle trap/interrupt/syscall according to the return value
 /// - return the context to the user thread
-fn spawn(thread: CurrentThread) {
-    let vmtoken = thread.proc().vmar().table_phys();
-    let future = async move {
-        loop {
-            // wait
-            let mut cx = thread.wait_for_run().await;
-            // run
-            trace!("go to user: {:#x?}", cx);
-            kernel_hal::context_run(&mut cx);
-            trace!("back from user: {:#x?}", cx);
-            // handle trap/interrupt/syscall
-            let mut exit = false;
-            match cx.trap_num {
-                0x100 => exit = handle_syscall(&thread, &mut cx.general).await,
-                0x20..=0x3f => {
-                    kernel_hal::InterruptManager::handle(cx.trap_num as u8);
-                    if cx.trap_num == 0x20 {
-                        kernel_hal::yield_now().await;
-                    }
-                }
-                0xe => {
-                    let vaddr = kernel_hal::fetch_fault_vaddr();
-                    let flags = if cx.error_code & 0x2 == 0 {
-                        MMUFlags::READ
-                    } else {
-                        MMUFlags::WRITE
-                    };
-                    error!("page fualt from user mode {:#x} {:#x?}", vaddr, flags);
-                    let vmar = thread.proc().vmar();
-                    match vmar.handle_page_fault(vaddr, flags) {
-                        Ok(()) => {}
-                        Err(_) => {
-                            panic!("Page Fault from user mode {:#x?}", cx);
-                        }
-                    }
-                }
-                _ => panic!("not supported interrupt from user mode. {:#x?}", cx),
-            }
-            thread.end_running(cx);
-            if exit {
-                break;
-            }
+async fn new_thread(thread: CurrentThread) {
+    loop {
+        // wait
+        let mut cx = thread.wait_for_run().await;
+        if thread.state() == ThreadState::Dying {
+            break;
         }
-    };
-    kernel_hal::Thread::spawn(Box::pin(future), vmtoken);
+        // run
+        trace!("go to user: {:#x?}", cx);
+        kernel_hal::context_run(&mut cx);
+        trace!("back from user: {:#x?}", cx);
+        // handle trap/interrupt/syscall
+        match cx.trap_num {
+            0x100 => handle_syscall(&thread, &mut cx.general).await,
+            0x20..=0x3f => {
+                kernel_hal::InterruptManager::handle(cx.trap_num as u8);
+                if cx.trap_num == 0x20 {
+                    kernel_hal::yield_now().await;
+                }
+            }
+            0xe => {
+                let vaddr = kernel_hal::fetch_fault_vaddr();
+                let flags = if cx.error_code & 0x2 == 0 {
+                    MMUFlags::READ
+                } else {
+                    MMUFlags::WRITE
+                };
+                error!("page fualt from user mode {:#x} {:#x?}", vaddr, flags);
+                let vmar = thread.proc().vmar();
+                match vmar.handle_page_fault(vaddr, flags) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        panic!("Page Fault from user mode {:#x?}", cx);
+                    }
+                }
+            }
+            _ => panic!("not supported interrupt from user mode. {:#x?}", cx),
+        }
+        thread.end_running(cx);
+    }
 }
 
-/// syscall handler entry: create a struct `syscall: Syscall`, and call `syscall.syscall()`
-async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) -> bool {
+fn thread_fn(thread: CurrentThread) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+    Box::pin(new_thread(thread))
+}
+
+/// syscall handler entry
+async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) {
     trace!("syscall: {:#x?}", regs);
     let num = regs.rax as u32;
     let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
@@ -111,12 +111,8 @@ async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) -> bool 
         syscall_entry: kernel_hal_unix::syscall_entry as usize,
         #[cfg(not(feature = "std"))]
         syscall_entry: 0,
-        spawn_fn: spawn,
+        thread_fn,
         regs,
-        exit: false,
     };
-    let ret = syscall.syscall(num, args).await;
-    let exit = syscall.exit;
-    regs.rax = ret as usize;
-    exit
+    regs.rax = syscall.syscall(num, args).await as usize;
 }

--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -53,7 +53,7 @@ pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) ->
 /// - enter user mode
 /// - handle trap/interrupt/syscall according to the return value
 /// - return the context to the user thread
-fn spawn(thread: Arc<Thread>) {
+fn spawn(thread: CurrentThread) {
     let vmtoken = thread.proc().vmar().table_phys();
     let future = async move {
         loop {
@@ -102,7 +102,7 @@ fn spawn(thread: Arc<Thread>) {
 }
 
 /// syscall handler entry: create a struct `syscall: Syscall`, and call `syscall.syscall()`
-async fn handle_syscall(thread: &Arc<Thread>, regs: &mut GeneralRegs) -> bool {
+async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) -> bool {
     trace!("syscall: {:#x?}", regs);
     let num = regs.rax as u32;
     let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];

--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -96,7 +96,6 @@ fn spawn(thread: CurrentThread) {
                 break;
             }
         }
-        thread.terminate();
     };
     kernel_hal::Thread::spawn(Box::pin(future), vmtoken);
 }

--- a/linux-object/src/thread.rs
+++ b/linux-object/src/thread.rs
@@ -5,7 +5,7 @@ use alloc::sync::Arc;
 use kernel_hal::user::{Out, UserOutPtr, UserPtr};
 use kernel_hal::VirtAddr;
 use spin::{Mutex, MutexGuard};
-use zircon_object::task::{Process, Thread};
+use zircon_object::task::{CurrentThread, Process, Thread};
 use zircon_object::ZxResult;
 
 /// Thread extension for linux
@@ -16,6 +16,10 @@ pub trait ThreadExt {
     fn lock_linux(&self) -> MutexGuard<'_, LinuxThread>;
     /// Set pointer to thread ID.
     fn set_tid_address(&self, tidptr: UserOutPtr<i32>);
+}
+
+/// CurrentThread extension for linux
+pub trait CurrentThreadExt {
     /// exit linux thread
     fn exit_linux(&self, exit_code: i32);
 }
@@ -39,7 +43,9 @@ impl ThreadExt for Thread {
     fn set_tid_address(&self, tidptr: UserPtr<i32, Out>) {
         self.lock_linux().clear_child_tid = tidptr;
     }
+}
 
+impl CurrentThreadExt for CurrentThread {
     /// Exit current thread for Linux.
     fn exit_linux(&self, _exit_code: i32) {
         let mut linux_thread = self.lock_linux();

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -11,9 +11,8 @@
 //!     syscall_entry: kernel_hal_unix::syscall_entry as usize,
 //!     #[cfg(not(feature = "std"))]
 //!     syscall_entry: 0,
-//!     spawn_fn: spawn,
+//!     thread_fn,
 //!     regs,
-//!     exit: false,
 //! };
 //! let ret = syscall.syscall(num, args).await;
 //! ```
@@ -59,10 +58,8 @@ pub struct Syscall<'a> {
     pub syscall_entry: VirtAddr,
     /// store the regs statues
     pub regs: &'a mut GeneralRegs,
-    /// the spawn function in linux-loader
-    pub spawn_fn: fn(thread: CurrentThread),
-    /// Set `true` to exit current task.
-    pub exit: bool,
+    /// new thread function
+    pub thread_fn: ThreadFn,
 }
 
 impl Syscall<'_> {
@@ -273,7 +270,6 @@ impl Syscall<'_> {
         error!("unknown syscall: {:?}. exit...", sys_type);
         let proc = self.zircon_process();
         proc.exit(-1);
-        self.exit = true;
         Err(LxError::ENOSYS)
     }
 

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -54,13 +54,13 @@ mod vm;
 /// The struct of Syscall which stores the information about making a syscall
 pub struct Syscall<'a> {
     /// the thread making a syscall
-    pub thread: &'a Arc<Thread>,
+    pub thread: &'a CurrentThread,
     /// the entry of current syscall
     pub syscall_entry: VirtAddr,
     /// store the regs statues
     pub regs: &'a mut GeneralRegs,
     /// the spawn function in linux-loader
-    pub spawn_fn: fn(thread: Arc<Thread>),
+    pub spawn_fn: fn(thread: CurrentThread),
     /// Set `true` to exit current task.
     pub exit: bool,
 }

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -15,7 +15,7 @@ use bitflags::bitflags;
 use core::fmt::Debug;
 use linux_object::fs::INodeExt;
 use linux_object::loader::LinuxElfLoader;
-use linux_object::thread::ThreadExt;
+use linux_object::thread::{CurrentThreadExt, ThreadExt};
 
 impl Syscall<'_> {
     /// Fork the current process. Return the child's PID.

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -23,7 +23,7 @@ impl Syscall<'_> {
         info!("fork:");
         let new_proc = Process::fork_from(self.zircon_process(), false)?;
         let new_thread = Thread::create_linux(&new_proc)?;
-        new_thread.start_with_regs(GeneralRegs::new_fork(self.regs), self.spawn_fn)?;
+        new_thread.start_with_regs(GeneralRegs::new_fork(self.regs), self.thread_fn)?;
 
         info!("fork: {} -> {}", self.zircon_process().id(), new_proc.id());
         Ok(new_proc.id() as usize)
@@ -34,7 +34,7 @@ impl Syscall<'_> {
         info!("vfork:");
         let new_proc = Process::fork_from(self.zircon_process(), true)?;
         let new_thread = Thread::create_linux(&new_proc)?;
-        new_thread.start_with_regs(GeneralRegs::new_fork(self.regs), self.spawn_fn)?;
+        new_thread.start_with_regs(GeneralRegs::new_fork(self.regs), self.thread_fn)?;
 
         let new_proc: Arc<dyn KernelObject> = new_proc;
         info!("vfork: {} -> {}", self.zircon_process().id(), new_proc.id());
@@ -73,7 +73,7 @@ impl Syscall<'_> {
         }
         let new_thread = Thread::create_linux(self.zircon_process())?;
         let regs = GeneralRegs::new_clone(self.regs, newsp, newtls);
-        new_thread.start_with_regs(regs, self.spawn_fn)?;
+        new_thread.start_with_regs(regs, self.thread_fn)?;
 
         let tid = new_thread.id();
         info!("clone: {} -> {}", self.thread.id(), tid);
@@ -240,7 +240,6 @@ impl Syscall<'_> {
     pub fn sys_exit(&mut self, exit_code: i32) -> SysResult {
         info!("exit: code={}", exit_code);
         self.thread.exit_linux(exit_code);
-        self.exit = true;
         Err(LxError::ENOSYS)
     }
 
@@ -249,7 +248,6 @@ impl Syscall<'_> {
         info!("exit_group: code={}", exit_code);
         let proc = self.zircon_process();
         proc.exit(exit_code as i64);
-        self.exit = true;
         Err(LxError::ENOSYS)
     }
 

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -10,6 +10,7 @@ extern crate log;
 
 use {
     alloc::{boxed::Box, sync::Arc, vec::Vec},
+    core::{future::Future, pin::Pin},
     kernel_hal::GeneralRegs,
     xmas_elf::ElfFile,
     zircon_object::{dev::*, ipc::*, object::*, task::*, util::elf_loader::*, vm::*},
@@ -163,7 +164,7 @@ pub fn run_userboot(images: &Images<impl AsRef<[u8]>>, cmdline: &str) -> Arc<Pro
     let msg = MessagePacket { data, handles };
     kernel_channel.write(msg).unwrap();
 
-    proc.start(&thread, entry, sp, Some(handle), 0, spawn)
+    proc.start(&thread, entry, sp, Some(handle), 0, thread_fn)
         .expect("failed to start main thread");
     proc
 }
@@ -172,99 +173,99 @@ kcounter!(EXCEPTIONS_USER, "exceptions.user");
 kcounter!(EXCEPTIONS_TIMER, "exceptions.timer");
 kcounter!(EXCEPTIONS_PGFAULT, "exceptions.pgfault");
 
-fn spawn(thread: CurrentThread) {
-    let vmtoken = thread.proc().vmar().table_phys();
-    let future = async move {
-        kernel_hal::Thread::set_tid(thread.id(), thread.proc().id());
-        if thread.is_first_thread() {
-            thread
-                .handle_exception(ExceptionType::ProcessStarting, None)
-                .await;
-        };
+async fn new_thread(thread: CurrentThread) {
+    kernel_hal::Thread::set_tid(thread.id(), thread.proc().id());
+    if thread.is_first_thread() {
         thread
-            .handle_exception(ExceptionType::ThreadStarting, None)
-            .await;
-
-        loop {
-            let mut cx = thread.wait_for_run().await;
-            if thread.state() == ThreadState::Dying {
-                break;
-            }
-            trace!("go to user: {:#x?}", cx);
-            debug!("switch to {}|{}", thread.proc().name(), thread.name());
-            let tmp_time = kernel_hal::timer_now().as_nanos();
-
-            // * Attention
-            // The code will enter a magic zone from here.
-            // ‘context run‘ will be executed into a wrapped library where context switching takes place.
-            // The details are available in the trapframe crate on crates.io.
-
-            kernel_hal::context_run(&mut cx);
-
-            // Back from the userspace
-
-            let time = kernel_hal::timer_now().as_nanos() - tmp_time;
-            thread.time_add(time);
-            trace!("back from user: {:#x?}", cx);
-            EXCEPTIONS_USER.add(1);
-            #[cfg(target_arch = "aarch64")]
-            match cx.trap_num {
-                0 => handle_syscall(&thread, &mut cx.general).await,
-                _ => unimplemented!(),
-            }
-            #[cfg(target_arch = "x86_64")]
-            match cx.trap_num {
-                0x100 => handle_syscall(&thread, &mut cx.general).await,
-                0x20..=0x3f => {
-                    kernel_hal::InterruptManager::handle(cx.trap_num as u8);
-                    if cx.trap_num == 0x20 {
-                        EXCEPTIONS_TIMER.add(1);
-                        kernel_hal::yield_now().await;
-                    }
-                }
-                0xe => {
-                    EXCEPTIONS_PGFAULT.add(1);
-                    #[cfg(target_arch = "x86_64")]
-                    let flags = if cx.error_code & 0x2 == 0 {
-                        MMUFlags::READ
-                    } else {
-                        MMUFlags::WRITE
-                    };
-                    // FIXME:
-                    #[cfg(target_arch = "aarch64")]
-                    let flags = MMUFlags::WRITE;
-                    let fault_vaddr = kernel_hal::fetch_fault_vaddr();
-                    error!("page fault from user mode {:#x} {:#x?}", fault_vaddr, flags);
-                    let vmar = thread.proc().vmar();
-                    if vmar.handle_page_fault(fault_vaddr, flags).is_err() {
-                        error!("Page Fault from user mode: {:#x?}", cx);
-                        thread
-                            .handle_exception(ExceptionType::FatalPageFault, Some(&cx))
-                            .await;
-                    }
-                }
-                0x8 => {
-                    panic!("Double fault from user mode! {:#x?}", cx);
-                }
-                num => {
-                    let type_ = match num {
-                        0x1 => ExceptionType::HardwareBreakpoint,
-                        0x3 => ExceptionType::SoftwareBreakpoint,
-                        0x6 => ExceptionType::UndefinedInstruction,
-                        0x17 => ExceptionType::UnalignedAccess,
-                        _ => ExceptionType::General,
-                    };
-                    error!("User mode exception: {:?} {:#x?}", type_, cx);
-                    thread.handle_exception(type_, Some(&cx)).await;
-                }
-            }
-            thread.end_running(cx);
-        }
-        thread
-            .handle_exception(ExceptionType::ThreadExiting, None)
+            .handle_exception(ExceptionType::ProcessStarting, None)
             .await;
     };
-    kernel_hal::Thread::spawn(Box::pin(future), vmtoken);
+    thread
+        .handle_exception(ExceptionType::ThreadStarting, None)
+        .await;
+
+    loop {
+        let mut cx = thread.wait_for_run().await;
+        if thread.state() == ThreadState::Dying {
+            break;
+        }
+        trace!("go to user: {:#x?}", cx);
+        debug!("switch to {}|{}", thread.proc().name(), thread.name());
+        let tmp_time = kernel_hal::timer_now().as_nanos();
+
+        // * Attention
+        // The code will enter a magic zone from here.
+        // `context run` will be executed into a wrapped library where context switching takes place.
+        // The details are available in the trapframe crate on crates.io.
+
+        kernel_hal::context_run(&mut cx);
+
+        // Back from the userspace
+
+        let time = kernel_hal::timer_now().as_nanos() - tmp_time;
+        thread.time_add(time);
+        trace!("back from user: {:#x?}", cx);
+        EXCEPTIONS_USER.add(1);
+        #[cfg(target_arch = "aarch64")]
+        match cx.trap_num {
+            0 => handle_syscall(&thread, &mut cx.general).await,
+            _ => unimplemented!(),
+        }
+        #[cfg(target_arch = "x86_64")]
+        match cx.trap_num {
+            0x100 => handle_syscall(&thread, &mut cx.general).await,
+            0x20..=0x3f => {
+                kernel_hal::InterruptManager::handle(cx.trap_num as u8);
+                if cx.trap_num == 0x20 {
+                    EXCEPTIONS_TIMER.add(1);
+                    kernel_hal::yield_now().await;
+                }
+            }
+            0xe => {
+                EXCEPTIONS_PGFAULT.add(1);
+                #[cfg(target_arch = "x86_64")]
+                let flags = if cx.error_code & 0x2 == 0 {
+                    MMUFlags::READ
+                } else {
+                    MMUFlags::WRITE
+                };
+                // FIXME:
+                #[cfg(target_arch = "aarch64")]
+                let flags = MMUFlags::WRITE;
+                let fault_vaddr = kernel_hal::fetch_fault_vaddr();
+                error!("page fault from user mode {:#x} {:#x?}", fault_vaddr, flags);
+                let vmar = thread.proc().vmar();
+                if vmar.handle_page_fault(fault_vaddr, flags).is_err() {
+                    error!("Page Fault from user mode: {:#x?}", cx);
+                    thread
+                        .handle_exception(ExceptionType::FatalPageFault, Some(&cx))
+                        .await;
+                }
+            }
+            0x8 => {
+                panic!("Double fault from user mode! {:#x?}", cx);
+            }
+            num => {
+                let type_ = match num {
+                    0x1 => ExceptionType::HardwareBreakpoint,
+                    0x3 => ExceptionType::SoftwareBreakpoint,
+                    0x6 => ExceptionType::UndefinedInstruction,
+                    0x17 => ExceptionType::UnalignedAccess,
+                    _ => ExceptionType::General,
+                };
+                error!("User mode exception: {:?} {:#x?}", type_, cx);
+                thread.handle_exception(type_, Some(&cx)).await;
+            }
+        }
+        thread.end_running(cx);
+    }
+    thread
+        .handle_exception(ExceptionType::ThreadExiting, None)
+        .await;
+}
+
+fn thread_fn(thread: CurrentThread) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+    Box::pin(new_thread(thread))
 }
 
 async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) {
@@ -296,7 +297,7 @@ async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) {
     let mut syscall = Syscall {
         regs,
         thread,
-        spawn_fn: spawn,
+        thread_fn,
     };
     let ret = syscall.syscall(num, args).await as usize;
     #[cfg(target_arch = "x86_64")]

--- a/zircon-loader/src/lib.rs
+++ b/zircon-loader/src/lib.rs
@@ -267,7 +267,6 @@ fn spawn(thread: CurrentThread) {
         if let Ok(future) = handled {
             thread.dying_run(future).await.ok();
         }
-        thread.terminate();
     };
     kernel_hal::Thread::spawn(Box::pin(future), vmtoken);
 }

--- a/zircon-object/src/hypervisor/guest.rs
+++ b/zircon-object/src/hypervisor/guest.rs
@@ -114,7 +114,7 @@ impl GuestPhysMemorySetTrait for GuestPhysMemorySet {
                 .handle_page_fault(gpaddr, mapping.get_flags())
                 .map_err(From::from)
         } else {
-            return Err(RvmError::NotFound);
+            Err(RvmError::NotFound)
         }
     }
 

--- a/zircon-object/src/hypervisor/mod.rs
+++ b/zircon-object/src/hypervisor/mod.rs
@@ -48,6 +48,7 @@ pub struct VmmPageTable(ArchRvmPageTable);
 struct VmmPageTableFlags(MMUFlags);
 
 impl VmmPageTable {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(ArchRvmPageTable::new())
     }

--- a/zircon-object/src/task/exception.rs
+++ b/zircon-object/src/task/exception.rs
@@ -634,7 +634,7 @@ mod tests {
         // since exception is handled we should not get it from parent job
         create_handler(&parent_job.exceptionate(), false, false, 4);
 
-        exception.handle(false).await;
+        exception.handle().await;
 
         // terminate handlers by shutdown the related exceptionates
         thread.exceptionate().shutdown();

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -115,7 +115,6 @@ impl Process {
         name: &str,
         ext: impl Any + Send + Sync,
     ) -> ZxResult<Arc<Self>> {
-        // TODO: _options -> options
         let proc = Arc::new(Process {
             base: KObjectBase::with_name(name),
             _counter: CountHelper::new(),
@@ -145,7 +144,7 @@ impl Process {
         stack: usize,
         arg1: Option<Handle>,
         arg2: usize,
-        spawn_fn: fn(thread: Arc<Thread>),
+        spawn_fn: fn(thread: CurrentThread),
     ) -> ZxResult {
         let handle_value;
         {

--- a/zircon-object/src/task/process.rs
+++ b/zircon-object/src/task/process.rs
@@ -144,7 +144,7 @@ impl Process {
         stack: usize,
         arg1: Option<Handle>,
         arg2: usize,
-        spawn_fn: fn(thread: CurrentThread),
+        thread_fn: ThreadFn,
     ) -> ZxResult {
         let handle_value;
         {
@@ -159,7 +159,7 @@ impl Process {
             handle_value = arg1.map_or(INVALID_HANDLE, |handle| inner.add_handle(handle));
         }
         thread.set_first_thread();
-        match thread.start(entry, stack, handle_value as usize, arg2, spawn_fn) {
+        match thread.start(entry, stack, handle_value as usize, arg2, thread_fn) {
             Ok(_) => Ok(()),
             Err(err) => {
                 let mut inner = self.inner.lock();

--- a/zircon-object/src/task/suspend_token.rs
+++ b/zircon-object/src/task/suspend_token.rs
@@ -1,11 +1,43 @@
 use {
-    // super::thread::Thread,
     super::*,
     crate::object::*,
     alloc::sync::{Arc, Weak},
 };
 
-/// Suspend the given task. Currently only thread or process handles may be suspended.
+/// Suspend the given task.
+///
+/// Currently only thread or process handles may be suspended.
+///
+/// # Example
+/// ```
+/// # use std::sync::Arc;
+/// # use zircon_object::task::*;
+/// # use zircon_object::object::{KernelObject, Signal};
+/// # kernel_hal_unix::init();
+/// let job = Job::root();
+/// let proc = Process::create(&job, "proc").unwrap();
+/// let thread = Thread::create(&proc, "thread").unwrap();
+///
+/// // start the thread and never terminate
+/// thread.start(0, 0, 0, 0, |thread| Box::pin(async move {
+///     loop { async_std::task::yield_now().await }
+///     let _ = thread;
+/// })).unwrap();
+///
+/// // wait for the thread running
+/// let object: Arc<dyn KernelObject> = thread.clone();
+/// async_std::task::block_on(object.wait_signal(Signal::THREAD_RUNNING));
+/// assert_eq!(thread.state(), ThreadState::Running);
+///
+/// // suspend the thread
+/// {
+///     let task: Arc<dyn Task> = thread.clone();
+///     let suspend_token = SuspendToken::create(&task);
+///     assert_eq!(thread.state(), ThreadState::Suspended);
+/// }
+/// // suspend token dropped, resume the thread
+/// assert_eq!(thread.state(), ThreadState::Running);
+/// ```
 pub struct SuspendToken {
     base: KObjectBase,
     task: Weak<dyn Task>,

--- a/zircon-object/src/task/thread.rs
+++ b/zircon-object/src/task/thread.rs
@@ -187,6 +187,20 @@ impl Thread {
     }
 
     /// Create a new thread with extension info.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use zircon_object::task::*;
+    /// # kernel_hal_unix::init();
+    /// let job = Job::root();
+    /// let proc = Process::create(&job, "proc").unwrap();
+    /// // create a thread with extension info
+    /// let thread = Thread::create_with_ext(&proc, "thread", job.clone()).unwrap();
+    /// // get the extension info
+    /// let ext = thread.ext().downcast_ref::<Arc<Job>>().unwrap();
+    /// assert!(Arc::ptr_eq(ext, &job));
+    /// ```
     pub fn create_with_ext(
         proc: &Arc<Process>,
         name: &str,
@@ -212,7 +226,7 @@ impl Thread {
         &self.proc
     }
 
-    /// Get the extension.
+    /// Get the extension info.
     pub fn ext(&self) -> &Box<dyn Any + Send + Sync> {
         &self.ext
     }

--- a/zircon-syscall/src/futex.rs
+++ b/zircon-syscall/src/futex.rs
@@ -1,4 +1,7 @@
-use {super::*, zircon_object::task::ThreadState};
+use {
+    super::*,
+    zircon_object::task::{Thread, ThreadState},
+};
 
 impl Syscall<'_> {
     /// Wait on a futex.  
@@ -27,7 +30,7 @@ impl Syscall<'_> {
         } else {
             Some(proc.get_object::<Thread>(new_futex_owner)?)
         };
-        let future = futex.wait_with_owner(current_value, Some(self.thread.clone()), new_owner);
+        let future = futex.wait_with_owner(current_value, Some((*self.thread).clone()), new_owner);
         self.thread
             .blocking_run(future, ThreadState::BlockedFutex, deadline.into(), None)
             .await?;

--- a/zircon-syscall/src/hypervisor.rs
+++ b/zircon-syscall/src/hypervisor.rs
@@ -98,7 +98,7 @@ impl Syscall<'_> {
         }
         let proc = self.thread.proc();
         let guest = proc.get_object_with_rights::<Guest>(guest_handle, Rights::MANAGE_PROCESS)?;
-        let vcpu = Vcpu::new(guest, entry, self.thread.clone())?;
+        let vcpu = Vcpu::new(guest, entry, (*self.thread).clone())?;
         let handle_value = proc.add_handle(Handle::new(vcpu, Rights::DEFAULT_VCPU));
         out.write(handle_value)?;
         Ok(())

--- a/zircon-syscall/src/lib.rs
+++ b/zircon-syscall/src/lib.rs
@@ -19,7 +19,7 @@ use {
     futures::pin_mut,
     kernel_hal::{user::*, GeneralRegs},
     zircon_object::object::*,
-    zircon_object::task::Thread,
+    zircon_object::task::CurrentThread,
 };
 
 mod channel;
@@ -51,8 +51,8 @@ use consts::SyscallType as Sys;
 
 pub struct Syscall<'a> {
     pub regs: &'a mut GeneralRegs,
-    pub thread: Arc<Thread>,
-    pub spawn_fn: fn(thread: Arc<Thread>),
+    pub thread: &'a CurrentThread,
+    pub spawn_fn: fn(thread: CurrentThread),
 }
 
 impl Syscall<'_> {

--- a/zircon-syscall/src/lib.rs
+++ b/zircon-syscall/src/lib.rs
@@ -19,7 +19,7 @@ use {
     futures::pin_mut,
     kernel_hal::{user::*, GeneralRegs},
     zircon_object::object::*,
-    zircon_object::task::CurrentThread,
+    zircon_object::task::{CurrentThread, ThreadFn},
 };
 
 mod channel;
@@ -52,7 +52,7 @@ use consts::SyscallType as Sys;
 pub struct Syscall<'a> {
     pub regs: &'a mut GeneralRegs,
     pub thread: &'a CurrentThread,
-    pub spawn_fn: fn(thread: CurrentThread),
+    pub thread_fn: ThreadFn,
 }
 
 impl Syscall<'_> {

--- a/zircon-syscall/src/task.rs
+++ b/zircon-syscall/src/task.rs
@@ -103,7 +103,7 @@ impl Syscall<'_> {
         } else {
             None
         };
-        process.start(&thread, entry, stack, arg1, arg2, self.spawn_fn)?;
+        process.start(&thread, entry, stack, arg1, arg2, self.thread_fn)?;
         Ok(())
     }
 
@@ -174,7 +174,7 @@ impl Syscall<'_> {
         if thread.proc().status() != Status::Running {
             return Err(ZxError::BAD_STATE);
         }
-        thread.start(entry, stack, arg1, arg2, self.spawn_fn)?;
+        thread.start(entry, stack, arg1, arg2, self.thread_fn)?;
         Ok(())
     }
 


### PR DESCRIPTION
* Split some methods from `Thread` to `CurrentThread`.
  `CurrentThread` can only be obtained from the spawned future that running the new thread, while `Thread` can be accessed by all other threads.
  The lifetime of `CurrentThread` is associated with the thread state. We moved `thread.terminate()` to `current_thread.drop()`, which means the thread will terminate implicitly on its drop.

* Modify `spawn_fn` to `thread_fn`.
  Now you only need to give the function of new thread, the `Thread` object will spawn it internally.

* Hide `Exception` struct.
  The only way to issue an exception is `current_thread.handle_exception(...).await`.

* Add some doc tests.
  Maybe we should move more unit tests into docs in the future.

Request review from @benpigchu 