### PR TITLE
fix dynamic link path for envs in shell and add async poll in pipe

### DIFF
--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -37,7 +37,8 @@ pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) ->
     };
     let inode = rootfs.root_inode().lookup(&args[0]).unwrap();
     let data = inode.read_as_vec().unwrap();
-    let (entry, sp) = loader.load(&proc.vmar(), &data, args, envs).unwrap();
+    let path = args[0].clone();
+    let (entry, sp) = loader.load(&proc.vmar(), &data, args, envs, path).unwrap();
 
     thread
         .start(entry, sp, 0, 0, spawn)

--- a/linux-object/src/loader/mod.rs
+++ b/linux-object/src/loader/mod.rs
@@ -30,14 +30,17 @@ impl LinuxElfLoader {
         data: &[u8],
         mut args: Vec<String>,
         envs: Vec<String>,
+        path: String,
     ) -> LxResult<(VirtAddr, VirtAddr)> {
+        info!("load: vmar: {:?} args: {:?}, envs: {:?}", vmar, args, envs);
         let elf = ElfFile::new(data).map_err(|_| ZxError::INVALID_ARGS)?;
         if let Ok(interp) = elf.get_interpreter() {
             info!("interp: {:?}", interp);
             let inode = self.root_inode.lookup(interp)?;
             let data = inode.read_as_vec()?;
+            args[0] = path.clone();
             args.insert(0, interp.into());
-            return self.load(vmar, &data, args, envs);
+            return self.load(vmar, &data, args, envs, path);
         }
 
         let size = elf.load_segment_size();

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -173,7 +173,7 @@ impl Syscall<'_> {
             stack_pages: 8,
             root_inode: proc.root_inode().clone(),
         };
-        let (entry, sp) = loader.load(&vmar, &data, args, envs)?;
+        let (entry, sp) = loader.load(&vmar, &data, args, envs, path.clone())?;
 
         // Modify exec path
         proc.set_execute_path(&path);


### PR DESCRIPTION
Now, if the command file is link to relative path, it can be run from shell directly.

- if the command file is link to abstract path...I'm trying to figure it out in the rcore-fs.

## other

- add async_poll for pipe