### PR TITLE
fix regression/rlimit-open-files.exe in libc-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 /rootfs
 /prebuilt/linux/alpine*
 .idea
+scripts/linux/test-result.txt

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Run Linux musl libc-tests for CI:
 
 ```sh
 make rootfs && make libc-test
-cd script && python3 libc-tests.py
+cd scripts && python3 libc-tests.py
 # Check `linux/test-result.txt` for results.
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run all (non-panicked) core-tests for CI:
 
 ```sh
 pip3 install pexpect
-cd script && python3 core-tests.py
+cd scripts && python3 core-tests.py
 # Check `zircon/test-result.txt` for results.
 ```
 

--- a/linux-loader/src/main.rs
+++ b/linux-loader/src/main.rs
@@ -169,6 +169,11 @@ mod tests {
         fs::read("../rootfs/testtruncate").unwrap();
     }
 
+    #[async_std::test]
+    async fn test_flock() {
+        assert_eq!(test("/bin/busybox flock 0").await, 0);
+    }
+
     // syscall unit test
 
     #[async_std::test]

--- a/linux-object/src/lib.rs
+++ b/linux-object/src/lib.rs
@@ -1,7 +1,13 @@
 //! Linux kernel objects
 
 #![no_std]
-#![deny(warnings, unsafe_code, unused_must_use, unreachable_patterns)]
+#![deny(
+    warnings,
+    unsafe_code,
+    unused_must_use,
+    unreachable_patterns,
+    missing_docs
+)]
 #![feature(bool_to_option)]
 
 extern crate alloc;

--- a/linux-object/src/process.rs
+++ b/linux-object/src/process.rs
@@ -157,8 +157,10 @@ struct LinuxProcessInner {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct RLimit {
-    pub cur: u64, // soft limit
-    pub max: u64, // hard limit
+    /// soft limit
+    pub cur: u64,
+    /// hard limit
+    pub max: u64,
 }
 
 impl Default for RLimit {
@@ -254,9 +256,10 @@ impl LinuxProcess {
         }
     }
 
+    /// get and set file limit number
     pub fn file_limit(&self, new_limit: Option<RLimit>) -> RLimit {
         let mut inner = self.inner.lock();
-        let old = inner.file_limit.clone();
+        let old = inner.file_limit;
         if let Some(limit) = new_limit {
             inner.file_limit = limit;
         }

--- a/linux-object/src/sync/mod.rs
+++ b/linux-object/src/sync/mod.rs
@@ -1,3 +1,4 @@
+//! Useful synchronization primitives.
 pub use self::event_bus::*;
 
 mod event_bus;

--- a/linux-syscall/src/file/fd.rs
+++ b/linux-syscall/src/file/fd.rs
@@ -74,6 +74,16 @@ impl Syscall<'_> {
         Ok(fd2.into())
     }
 
+    /// create a copy of the file descriptor fd, and uses the lowest-numbered unused descriptor for the new descriptor.
+    pub fn sys_dup(&self, fd1: FileDesc) -> SysResult {
+        info!("dup: from {:?}", fd1);
+        let proc = self.linux_process();
+
+        let file_like = proc.get_file_like(fd1)?;
+        let fd2 = proc.add_file(file_like)?;
+        Ok(fd2.into())
+    }
+
     /// Creates a pipe, a unidirectional data channel that can be used for interprocess communication.
     pub fn sys_pipe(&self, mut fds: UserOutPtr<[i32; 2]>) -> SysResult {
         info!("pipe: fds={:?}", fds);

--- a/linux-syscall/src/file/fd.rs
+++ b/linux-syscall/src/file/fd.rs
@@ -70,7 +70,7 @@ impl Syscall<'_> {
         // close fd2 first if it is opened
         let _ = proc.close_file(fd2);
         let file_like = proc.get_file_like(fd1)?;
-        proc.add_file_at(fd2, file_like);
+        let fd2 = proc.add_file_at(fd2, file_like)?;
         Ok(fd2.into())
     }
 

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -108,6 +108,7 @@ impl Syscall<'_> {
             Sys::FCHOWN => self.unimplemented("fchown", Ok(0)),
             Sys::FCHOWNAT => self.unimplemented("fchownat", Ok(0)),
             Sys::FACCESSAT => self.sys_faccessat(a0.into(), a1.into(), a2, a3),
+            Sys::DUP => self.sys_dup(a0.into()),
             Sys::DUP3 => self.sys_dup2(a0.into(), a1.into()), // TODO: handle `flags`
             Sys::PIPE2 => self.sys_pipe(a0.into()),           // TODO: handle `flags`
             Sys::UTIMENSAT => self.sys_utimensat(a0.into(), a1.into(), a2.into(), a3),


### PR DESCRIPTION
## syscalls

- add dup syscall
- add support of max open file numbers in process
- support set max open file numbers in prlimit64

## minor fix

- fix `cd` path in readme
- add generate file `linux/test-result.txt` in gitignore
- readd #[deny(missing_docs)] in `linux-object`