### PR TITLE
Add syscall thread_read_state

### DIFF
--- a/zircon-syscall/src/lib.rs
+++ b/zircon-syscall/src/lib.rs
@@ -102,6 +102,9 @@ impl Syscall<'_> {
                 self.sys_thread_create(a0 as _, a1.into(), a2 as _, a3 as _, a4.into())
             }
             Sys::THREAD_START => self.sys_thread_start(a0 as _, a1 as _, a2 as _, a3 as _, a4 as _),
+            Sys::THREAD_READ_STATE => {
+                self.sys_thread_read_state(a0 as _, a1 as _, a2.into(), a3 as _)
+            }
             Sys::THREAD_WRITE_STATE => {
                 self.sys_thread_write_state(a0 as _, a1 as _, a2.into(), a3 as _)
             }

--- a/zircon-syscall/src/task.rs
+++ b/zircon-syscall/src/task.rs
@@ -107,6 +107,28 @@ impl Syscall<'_> {
         Ok(())
     }
 
+    /// Read one aspect of thread state.    
+    ///   
+    /// The thread state may only be read when the thread is halted for an exception or the thread is suspended.
+    pub fn sys_thread_read_state(
+        &self,
+        handle: HandleValue,
+        kind: u32,
+        buffer: UserOutPtr<u8>,
+        buffer_size: usize,
+    ) -> ZxResult {
+        let kind = ThreadStateKind::try_from(kind).map_err(|_| ZxError::INVALID_ARGS)?;
+        info!(
+            "thread.read_state: handle={:#x?}, kind={:#x?}, buf=({:#x?}; {:#x?})",
+            handle, kind, buffer, buffer_size,
+        );
+        let proc = self.thread.proc();
+        let thread = proc.get_object_with_rights::<Thread>(handle, Rights::READ)?;
+        let mut buf = vec![0u8; buffer_size];
+        thread.read_state(kind, &mut buf[..buffer_size])?;
+        Ok(())
+    }
+
     /// Write one aspect of thread state.    
     ///   
     /// The thread state may only be written when the thread is halted for an exception or the thread is suspended.


### PR DESCRIPTION
Is there any special reason for not adding this syscall, as I see the underlying implementation is already complete.
If it's just missing, then I'll add it!