### PR TITLE
fix tests about comparing `Arc<dyn KernelObject>`

### DIFF
--- a/zircon-object/src/task/job.rs
+++ b/zircon-object/src/task/job.rs
@@ -304,10 +304,14 @@ mod tests {
     #[test]
     fn create() {
         let root_job = Job::root();
-        let job: Arc<dyn KernelObject> =
-            Job::create_child(&root_job).expect("failed to create job");
+        let job = Job::create_child(&root_job).expect("failed to create job");
 
-        assert!(Arc::ptr_eq(&root_job.get_child(job.id()).unwrap(), &job));
+        let child = root_job
+            .get_child(job.id())
+            .unwrap()
+            .downcast_arc()
+            .unwrap();
+        assert!(Arc::ptr_eq(&child, &job));
         assert_eq!(job.related_koid(), root_job.id());
         assert_eq!(root_job.related_koid(), 0);
 

--- a/zircon-object/src/task/thread.rs
+++ b/zircon-object/src/task/thread.rs
@@ -740,9 +740,9 @@ mod tests {
         let thread = Thread::create(&proc, "thread").expect("failed to create thread");
         assert_eq!(thread.flags(), ThreadFlag::empty());
 
-        let thread: Arc<dyn KernelObject> = thread;
         assert_eq!(thread.related_koid(), proc.id());
-        assert!(Arc::ptr_eq(&proc.get_child(thread.id()).unwrap(), &thread));
+        let child = proc.get_child(thread.id()).unwrap().downcast_arc().unwrap();
+        assert!(Arc::ptr_eq(&child, &thread));
     }
 
     #[async_std::test]


### PR DESCRIPTION
These sometimes fail on my computer.
Comparing fat pointers to trait objects seems to be unstable.
ref: https://github.com/rust-lang/rust/issues/46139  https://github.com/rust-lang/rust/issues/69757