### PR TITLE
Some libc has no support for getrandom

### DIFF
--- a/linux-syscall/test/testrandom.c
+++ b/linux-syscall/test/testrandom.c
@@ -1,9 +1,18 @@
+#ifdef HAVE_GETRANDOM
  #include <sys/random.h>
+#else
+ #include <syscall.h>
+ #include <linux/random.h>
+#endif
  #include <stdio.h>
 
  int main(){
     int buf;
+#ifdef HAVE_GETRANDOM
     getrandom((void *)&buf,sizeof(buf),GRND_RANDOM);
+#else
+    syscall(SYS_getrandom, (void *)&buf, sizeof(buf), GRND_RANDOM);
+#endif
     printf("random: %d\n",buf);
     return 0;
  }


### PR DESCRIPTION
Such as in Ubuntu16.04. When running "make rootfs", got following error:

linux-syscall/test/testrandom.c:1:25: fatal error: sys/random.h: No such file or directory
compilation terminated.