### PR TITLE
Minor refactor VMO

### DIFF
--- a/kernel-hal-bare/src/lib.rs
+++ b/kernel-hal-bare/src/lib.rs
@@ -156,6 +156,15 @@ pub fn pmem_write(paddr: PhysAddr, buf: &[u8]) {
     }
 }
 
+/// Zero physical memory at `[paddr, paddr + len)`
+#[export_name = "hal_pmem_zero"]
+pub fn pmem_zero(paddr: PhysAddr, len: usize) {
+    trace!("pmem_zero: addr={:#x}, len={:#x}", paddr, len);
+    unsafe {
+        core::ptr::write_bytes(phys_to_virt(paddr) as *mut u8, 0, len);
+    }
+}
+
 /// Copy content of `src` frame to `target` frame
 #[export_name = "hal_frame_copy"]
 pub fn frame_copy(src: PhysAddr, target: PhysAddr) {
@@ -163,16 +172,6 @@ pub fn frame_copy(src: PhysAddr, target: PhysAddr) {
     unsafe {
         let buf = phys_to_virt(src) as *const u8;
         buf.copy_to_nonoverlapping(phys_to_virt(target) as _, PAGE_SIZE);
-    }
-}
-
-/// Zero `target` frame.
-#[export_name = "hal_frame_zero"]
-pub fn frame_zero_in_range(target: PhysAddr, start: usize, end: usize) {
-    assert!(start < PAGE_SIZE && end <= PAGE_SIZE);
-    trace!("frame_zero: {:#x}", target);
-    unsafe {
-        core::ptr::write_bytes(phys_to_virt(target + start) as *mut u8, 0, end - start);
     }
 }
 

--- a/kernel-hal-unix/src/lib.rs
+++ b/kernel-hal-unix/src/lib.rs
@@ -212,6 +212,17 @@ pub fn pmem_write(paddr: PhysAddr, buf: &[u8]) {
     }
 }
 
+/// Zero physical memory at `[paddr, paddr + len)`
+#[export_name = "hal_pmem_zero"]
+pub fn pmem_zero(paddr: PhysAddr, len: usize) {
+    trace!("pmem_zero: addr={:#x}, len={:#x}", paddr, len);
+    assert!(paddr + len <= PMEM_SIZE);
+    ensure_mmap_pmem();
+    unsafe {
+        core::ptr::write_bytes(phys_to_virt(paddr) as *mut u8, 0, len);
+    }
+}
+
 /// Copy content of `src` frame to `target` frame
 #[export_name = "hal_frame_copy"]
 pub fn frame_copy(src: PhysAddr, target: PhysAddr) {
@@ -221,17 +232,6 @@ pub fn frame_copy(src: PhysAddr, target: PhysAddr) {
     unsafe {
         let buf = phys_to_virt(src) as *const u8;
         buf.copy_to_nonoverlapping(phys_to_virt(target) as _, PAGE_SIZE);
-    }
-}
-
-/// Zero `target` frame.
-#[export_name = "hal_frame_zero"]
-pub fn frame_zero(target: PhysAddr) {
-    trace!("frame_zero: {:#x}", target);
-    assert!(target + PAGE_SIZE < PMEM_SIZE);
-    ensure_mmap_pmem();
-    unsafe {
-        core::ptr::write_bytes(phys_to_virt(target) as *mut u8, 0, PAGE_SIZE);
     }
 }
 

--- a/kernel-hal/src/dummy.rs
+++ b/kernel-hal/src/dummy.rs
@@ -231,17 +231,17 @@ pub fn pmem_write(_paddr: PhysAddr, _buf: &[u8]) {
     unimplemented!()
 }
 
+/// Zero physical memory at `[paddr, paddr + len)`
+#[linkage = "weak"]
+#[export_name = "hal_pmem_zero"]
+pub fn pmem_zero(_paddr: PhysAddr, _len: usize) {
+    unimplemented!()
+}
+
 /// Copy content of `src` frame to `target` frame.
 #[linkage = "weak"]
 #[export_name = "hal_frame_copy"]
 pub fn frame_copy(_src: PhysAddr, _target: PhysAddr) {
-    unimplemented!()
-}
-
-/// Zero `target` frame.
-#[linkage = "weak"]
-#[export_name = "hal_frame_zero"]
-pub fn frame_zero_in_range(_target: PhysAddr, _start: usize, _end: usize) {
     unimplemented!()
 }
 

--- a/zircon-object/src/vm/vmo/mod.rs
+++ b/zircon-object/src/vm/vmo/mod.rs
@@ -60,12 +60,7 @@ pub trait VMObjectTrait: Sync + Send {
     fn decommit(&self, offset: usize, len: usize) -> ZxResult;
 
     /// Create a child VMO.
-    fn create_child(
-        &self,
-        offset: usize,
-        len: usize,
-        user_id: KoID,
-    ) -> ZxResult<Arc<dyn VMObjectTrait>>;
+    fn create_child(&self, offset: usize, len: usize) -> ZxResult<Arc<dyn VMObjectTrait>>;
 
     /// Append a mapping to the VMO's mapping list.
     fn append_mapping(&self, _mapping: Weak<VmMapping>) {}
@@ -143,7 +138,7 @@ impl VmObject {
         Arc::new(VmObject {
             resizable,
             _counter: CountHelper::new(),
-            trait_: VMObjectPaged::new(base.id, pages),
+            trait_: VMObjectPaged::new(pages),
             inner: Mutex::new(VmObjectInner::default()),
             base,
         })
@@ -169,7 +164,7 @@ impl VmObject {
         }
         let base = KObjectBase::with_signal(Signal::VMO_ZERO_CHILDREN);
         let size_page = pages(size);
-        let trait_ = VMObjectPaged::new(base.id, size_page);
+        let trait_ = VMObjectPaged::new(size_page);
         trait_.create_contiguous(size, align_log2)?;
         let vmo = Arc::new(VmObject {
             base,
@@ -190,7 +185,7 @@ impl VmObject {
     ) -> ZxResult<Arc<Self>> {
         let base = KObjectBase::with_signal(Signal::VMO_ZERO_CHILDREN);
         base.set_name(&self.base.name());
-        let trait_ = self.trait_.create_child(offset, len, base.id)?;
+        let trait_ = self.trait_.create_child(offset, len)?;
         let child = Arc::new(VmObject {
             base,
             resizable,

--- a/zircon-object/src/vm/vmo/mod.rs
+++ b/zircon-object/src/vm/vmo/mod.rs
@@ -156,21 +156,12 @@ impl VmObject {
     }
 
     /// Create a VM object referring to a specific contiguous range of physical frame.  
-    pub fn new_contiguous(p_size: usize, align_log2: usize) -> ZxResult<Arc<Self>> {
-        assert!(align_log2 < 8 * core::mem::size_of::<usize>());
-        let size = roundup_pages(p_size);
-        if size < p_size {
-            return Err(ZxError::INVALID_ARGS);
-        }
-        let base = KObjectBase::with_signal(Signal::VMO_ZERO_CHILDREN);
-        let size_page = pages(size);
-        let trait_ = VMObjectPaged::new(size_page);
-        trait_.create_contiguous(size, align_log2)?;
+    pub fn new_contiguous(pages: usize, align_log2: usize) -> ZxResult<Arc<Self>> {
         let vmo = Arc::new(VmObject {
-            base,
+            base: KObjectBase::with_signal(Signal::VMO_ZERO_CHILDREN),
             resizable: false,
             _counter: CountHelper::new(),
-            trait_,
+            trait_: VMObjectPaged::new_contiguous(pages, align_log2)?,
             inner: Mutex::new(VmObjectInner::default()),
         });
         Ok(vmo)

--- a/zircon-object/src/vm/vmo/physical.rs
+++ b/zircon-object/src/vm/vmo/physical.rs
@@ -128,8 +128,7 @@ mod tests {
     #[test]
     fn read_write() {
         let vmo = VmObject::new_physical(0x1000, 2);
-        let vmphy = vmo.inner.clone();
-        assert_eq!(vmphy.cache_policy(), CachePolicy::Uncached);
+        assert_eq!(vmo.cache_policy(), CachePolicy::Uncached);
         super::super::tests::read_write(&vmo);
     }
 }

--- a/zircon-object/src/vm/vmo/physical.rs
+++ b/zircon-object/src/vm/vmo/physical.rs
@@ -86,12 +86,7 @@ impl VMObjectTrait for VMObjectPhysical {
         Ok(())
     }
 
-    fn create_child(
-        &self,
-        _offset: usize,
-        _len: usize,
-        _user_id: KoID,
-    ) -> ZxResult<Arc<dyn VMObjectTrait>> {
+    fn create_child(&self, _offset: usize, _len: usize) -> ZxResult<Arc<dyn VMObjectTrait>> {
         Err(ZxError::NOT_SUPPORTED)
     }
 

--- a/zircon-object/src/vm/vmo/slice.rs
+++ b/zircon-object/src/vm/vmo/slice.rs
@@ -70,12 +70,7 @@ impl VMObjectTrait for VMObjectSlice {
         self.parent.decommit(offset + self.offset, len)
     }
 
-    fn create_child(
-        &self,
-        _offset: usize,
-        _len: usize,
-        _user_id: u64,
-    ) -> ZxResult<Arc<dyn VMObjectTrait>> {
+    fn create_child(&self, _offset: usize, _len: usize) -> ZxResult<Arc<dyn VMObjectTrait>> {
         Err(ZxError::NOT_SUPPORTED)
     }
 

--- a/zircon-syscall/src/vmo.rs
+++ b/zircon-syscall/src/vmo.rs
@@ -230,7 +230,7 @@ impl Syscall<'_> {
         let proc = self.thread.proc();
         proc.check_policy(PolicyCondition::NewVMO)?;
         let _bti = proc.get_object_with_rights::<BusTransactionInitiator>(bti, Rights::MAP)?;
-        let vmo = VmObject::new_contiguous(size, align_log2)?;
+        let vmo = VmObject::new_contiguous(pages(size), align_log2)?;
         let handle_value = proc.add_handle(Handle::new(vmo, Rights::DEFAULT_VMO));
         out.write(handle_value)?;
         Ok(())


### PR DESCRIPTION
As the first step to simplify VMO code, move common code out of the VMO trait.