### PR TITLE
musl-libc-test was updated, so add /libc-test/src/regression/fgets-eo…

### DIFF
--- a/scripts/linux/test-allow-failed.txt
+++ b/scripts/linux/test-allow-failed.txt
@@ -48,3 +48,4 @@
 /libc-test/src/regression/malloc-brk-fail.exe
 /libc-test/src/regression/iconv-roundtrips.exe
 /libc-test/src/regression/sem_close-unmap.exe
+/libc-test/src/regression/fgets-eof.exe


### PR DESCRIPTION
…f.exe in scripts/linux/test-allow-failed.txt for CI libc-test in libos mode can pass