### PR TITLE
linux-loader: remove some magic numbers

### DIFF
--- a/kernel-hal/src/bare/arch/x86_64/mod.rs
+++ b/kernel-hal/src/bare/arch/x86_64/mod.rs
@@ -1,5 +1,4 @@
 mod drivers;
-mod trap;
 
 pub mod config;
 pub mod context;
@@ -8,6 +7,7 @@ pub mod interrupt;
 pub mod mem;
 pub mod special;
 pub mod timer;
+pub mod trap;
 pub mod vm;
 
 hal_fn_impl_default!(crate::hal_fn::console);

--- a/kernel-hal/src/bare/arch/x86_64/trap.rs
+++ b/kernel-hal/src/bare/arch/x86_64/trap.rs
@@ -2,47 +2,51 @@
 
 use trapframe::TrapFrame;
 
-// Reference: https://wiki.osdev.org/Exceptions
-const DIVIDE_ERROR: usize = 0;
-const DEBUG: usize = 1;
-const NON_MASKABLE_INTERRUPT: usize = 2;
-const BREAKPOINT: usize = 3;
-const OVERFLOW: usize = 4;
-const BOUND_RANGE_EXCEEDED: usize = 5;
-const INVALID_OPCODE: usize = 6;
-const DEVICE_NOT_AVAILABLE: usize = 7;
-const DOUBLE_FAULT: usize = 8;
-const COPROCESSOR_SEGMENT_OVERRUN: usize = 9;
-const INVALID_TSS: usize = 10;
-const SEGMENT_NOT_PRESENT: usize = 11;
-const STACK_SEGMENT_FAULT: usize = 12;
-const GENERAL_PROTECTION_FAULT: usize = 13;
-const PAGE_FAULT: usize = 14;
-const FLOATING_POINTEXCEPTION: usize = 16;
-const ALIGNMENT_CHECK: usize = 17;
-const MACHINE_CHECK: usize = 18;
-const SIMD_FLOATING_POINT_EXCEPTION: usize = 19;
-const VIRTUALIZATION_EXCEPTION: usize = 20;
-const SECURITY_EXCEPTION: usize = 30;
+pub mod consts {
+    // Reference: https://wiki.osdev.org/Exceptions
+    pub const DIVIDE_ERROR: usize = 0;
+    pub const DEBUG: usize = 1;
+    pub const NON_MASKABLE_INTERRUPT: usize = 2;
+    pub const BREAKPOINT: usize = 3;
+    pub const OVERFLOW: usize = 4;
+    pub const BOUND_RANGE_EXCEEDED: usize = 5;
+    pub const INVALID_OPCODE: usize = 6;
+    pub const DEVICE_NOT_AVAILABLE: usize = 7;
+    pub const DOUBLE_FAULT: usize = 8;
+    pub const COPROCESSOR_SEGMENT_OVERRUN: usize = 9;
+    pub const INVALID_TSS: usize = 10;
+    pub const SEGMENT_NOT_PRESENT: usize = 11;
+    pub const STACK_SEGMENT_FAULT: usize = 12;
+    pub const GENERAL_PROTECTION_FAULT: usize = 13;
+    pub const PAGE_FAULT: usize = 14;
+    pub const FLOATING_POINTEXCEPTION: usize = 16;
+    pub const ALIGNMENT_CHECK: usize = 17;
+    pub const MACHINE_CHECK: usize = 18;
+    pub const SIMD_FLOATING_POINT_EXCEPTION: usize = 19;
+    pub const VIRTUALIZATION_EXCEPTION: usize = 20;
+    pub const SECURITY_EXCEPTION: usize = 30;
 
-// IRQ vectors
-pub(super) const X86_INT_BASE: usize = 0x20;
-pub(super) const X86_INT_MAX: usize = 0xff;
+    // IRQ vectors
+    pub const X86_INT_BASE: usize = 0x20;
+    pub const X86_INT_MAX: usize = 0xff;
 
-pub(super) const X86_INT_LOCAL_APIC_BASE: usize = 0xf0;
-pub(super) const X86_INT_APIC_SPURIOUS: usize = X86_INT_LOCAL_APIC_BASE + 0x0;
-pub(super) const X86_INT_APIC_TIMER: usize = X86_INT_LOCAL_APIC_BASE + 0x1;
-pub(super) const X86_INT_APIC_ERROR: usize = X86_INT_LOCAL_APIC_BASE + 0x2;
+    pub const X86_INT_LOCAL_APIC_BASE: usize = 0xf0;
+    pub const X86_INT_APIC_SPURIOUS: usize = X86_INT_LOCAL_APIC_BASE + 0x0;
+    pub const X86_INT_APIC_TIMER: usize = X86_INT_LOCAL_APIC_BASE + 0x1;
+    pub const X86_INT_APIC_ERROR: usize = X86_INT_LOCAL_APIC_BASE + 0x2;
 
-// ISA IRQ numbers
-pub(super) const X86_ISA_IRQ_PIT: usize = 0;
-pub(super) const X86_ISA_IRQ_KEYBOARD: usize = 1;
-pub(super) const X86_ISA_IRQ_PIC2: usize = 2;
-pub(super) const X86_ISA_IRQ_COM2: usize = 3;
-pub(super) const X86_ISA_IRQ_COM1: usize = 4;
-pub(super) const X86_ISA_IRQ_CMOSRTC: usize = 8;
-pub(super) const X86_ISA_IRQ_MOUSE: usize = 12;
-pub(super) const X86_ISA_IRQ_IDE: usize = 14;
+    // ISA IRQ numbers
+    pub const X86_ISA_IRQ_PIT: usize = 0;
+    pub const X86_ISA_IRQ_KEYBOARD: usize = 1;
+    pub const X86_ISA_IRQ_PIC2: usize = 2;
+    pub const X86_ISA_IRQ_COM2: usize = 3;
+    pub const X86_ISA_IRQ_COM1: usize = 4;
+    pub const X86_ISA_IRQ_CMOSRTC: usize = 8;
+    pub const X86_ISA_IRQ_MOUSE: usize = 12;
+    pub const X86_ISA_IRQ_IDE: usize = 14;
+}
+
+pub use consts::*;
 
 fn breakpoint() {
     panic!("\nEXCEPTION: Breakpoint");

--- a/kernel-hal/src/bare/mod.rs
+++ b/kernel-hal/src/bare/mod.rs
@@ -13,7 +13,7 @@ pub mod mem;
 pub mod thread;
 pub mod timer;
 
-pub use self::arch::{config, context, cpu, interrupt, vm};
+pub use self::arch::{config, context, cpu, interrupt, trap, vm};
 pub use super::hal_fn::{rand, vdso};
 
 hal_fn_impl_default!(rand, vdso);

--- a/linux-loader/Cargo.toml
+++ b/linux-loader/Cargo.toml
@@ -17,6 +17,7 @@ kernel-hal = { path = "../kernel-hal" }
 rcore-fs-hostfs = { git = "https://github.com/rcore-os/rcore-fs", rev = "7c232ec", optional = true }
 env_logger = { version = "0.8", optional = true }
 async-std = { version = "1.9", features = ["attributes"], optional = true }
+cfg-if = "1.0"
 
 [features]
 default = ["std", "libos"]

--- a/linux-loader/src/arch/riscv/interrupt.rs
+++ b/linux-loader/src/arch/riscv/interrupt.rs
@@ -1,0 +1,84 @@
+use {
+    linux_syscall::Syscall,
+    zircon_object::task::*,
+    zircon_object::{object::KernelObject, ZxError, ZxResult},
+    kernel_hal::context::UserContext,
+};
+
+use riscv::register::scause::{Exception, Trap};
+use riscv::register::{scause, stval};
+
+pub async fn handler_user_trap(thread: &CurrentThread, cx: &mut UserContext) -> ZxResult {
+    let pid = thread.proc().id();
+
+    let trap_cause = scause::read();
+    if trap_cause.is_interrupt() {
+        kernel_hal::interrupt::handle_irq(trap_cause.code());
+        // Timer
+        if trap_cause == Interrupt::SupervisorTimer {
+            kernel_hal::thread::yield_now().await;
+        }
+    } else {
+        match trap_cause {
+            // syscall
+            Exception::UserEnvCall => handle_syscall(thread, cx).await,
+            // PageFault
+            Exception::InstructionPageFault | 
+            Exception::LoadPageFault | 
+            Exception::StorePageFault => {
+                let (vaddr, flags) = kernel_hal::context::fetch_page_fault_info(trap_num);
+                warn!(
+                    "page fault from user mode @ {:#x}({:?}), pid={}",
+                    vaddr, flags, pid
+                );
+                let vmar = thread.proc().vmar();
+                if let Err(err) = vmar.handle_page_fault(vaddr, flags) {
+                    error!(
+                        "Failed to handle page Fault from user mode @ {:#x}({:?}): {:?}\n{:#x?}",
+                        vaddr, flags, err, cx
+                    );
+                    return Err(err);
+                }
+            }
+            _ => {
+                error!(
+                    "not supported pid: {} exception {} from user mode. {:#x?}",
+                    pid, trap_num, cx
+                );
+                return Err(ZxError::NOT_SUPPORTED);
+            }
+        }
+    }
+
+
+    Ok(())
+}
+
+async fn handle_syscall(thread: &CurrentThread, cx: &mut UserContext) {
+    trace!("syscall: {:#x?}", cx.general);
+    let num = cx.general.a7 as u32;
+    let args = [
+        cx.general.a0,
+        cx.general.a1,
+        cx.general.a2,
+        cx.general.a3,
+        cx.general.a4,
+        cx.general.a5,
+    ];
+    // add before fork
+    cx.sepc += 4;
+
+    //注意, 此时的regs没有原context所有权，故无法通过此regs修改寄存器
+    //let regs = &mut (cx.general as GeneralRegs);
+
+    let mut syscall = Syscall {
+        thread,
+        #[cfg(feature = "std")]
+        syscall_entry: kernel_hal::context::syscall_entry as usize,
+        #[cfg(not(feature = "std"))]
+        syscall_entry: 0,
+        context: cx,
+        thread_fn,
+    };
+    cx.general.a0 = syscall.syscall(num, args).await as usize;
+}

--- a/linux-loader/src/arch/riscv/mod.rs
+++ b/linux-loader/src/arch/riscv/mod.rs
@@ -1,0 +1,3 @@
+pub mod interrupt;
+
+pub use interrupt::*;

--- a/linux-loader/src/arch/x86_64/interrupt.rs
+++ b/linux-loader/src/arch/x86_64/interrupt.rs
@@ -1,0 +1,60 @@
+use {
+    linux_syscall::Syscall,
+    zircon_object::task::*,
+    zircon_object::{object::KernelObject, ZxError, ZxResult},
+    kernel_hal::context::UserContext,
+};
+use super::*;
+use kernel_hal::context::GeneralRegs;
+use crate::thread_fn;
+
+pub async fn handler_user_trap(thread: &CurrentThread, cx: &mut UserContext) -> ZxResult {
+    let pid = thread.proc().id();
+
+    match cx.trap_num {
+        SYSCALL => handle_syscall(thread, &mut cx.general).await,
+        X86_INT_BASE..=X86_INT_MAX => {
+            kernel_hal::interrupt::handle_irq(cx.trap_num);
+            // TODO: configurable
+            if cx.trap_num == X86_INT_APIC_TIMER {
+                kernel_hal::thread::yield_now().await;
+            }
+        }
+        PAGE_FAULT => {
+            let (vaddr, flags) = kernel_hal::context::fetch_page_fault_info(cx.error_code);
+            warn!(
+                "page fault from user mode @ {:#x}({:?}), pid={}",
+                vaddr, flags, pid
+            );
+            let vmar = thread.proc().vmar();
+            if let Err(err) = vmar.handle_page_fault(vaddr, flags) {
+                error!(
+                    "Failed to handle page Fault from user mode @ {:#x}({:?}): {:?}\n{:#x?}",
+                    vaddr, flags, err, cx
+                );
+                return Err(err);
+            }
+        }
+        _ => {
+            error!("not supported interrupt from user mode. {:#x?}", cx);
+            return Err(ZxError::NOT_SUPPORTED);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) {
+    trace!("syscall: {:#x?}", regs);
+    let num = regs.rax as u32;
+    let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
+    let mut syscall = Syscall {
+        thread,
+        #[cfg(feature = "std")]
+        syscall_entry: kernel_hal::context::syscall_entry as usize,
+        #[cfg(not(feature = "std"))]
+        syscall_entry: 0,
+        thread_fn,
+        regs,
+    };
+    regs.rax = syscall.syscall(num, args).await as usize;
+}

--- a/linux-loader/src/arch/x86_64/mod.rs
+++ b/linux-loader/src/arch/x86_64/mod.rs
@@ -1,0 +1,8 @@
+pub mod interrupt;
+
+pub use interrupt::*;
+
+use kernel_hal::trap::consts::*;
+// REF: https://github.com/rcore-os/trapframe-rs/blob/master/src/arch/x86_64/syscall.S
+const SYSCALL: usize = 0x100;
+

--- a/linux-loader/src/lib.rs
+++ b/linux-loader/src/lib.rs
@@ -17,15 +17,21 @@ use {
         process::ProcessExt,
         thread::{CurrentThreadExt, ThreadExt},
     },
-    linux_syscall::Syscall,
     zircon_object::task::*,
-    zircon_object::{object::KernelObject, ZxError, ZxResult},
+    cfg_if::cfg_if,
 };
 
-use kernel_hal::context::UserContext;
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        #[path = "arch/x86_64/mod.rs"]
+        mod arch;
+    } else if #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))] {
+        #[path = "arch/riscv/mod.rs"]
+        mod arch;
+    }
+}
 
-#[cfg(target_arch = "x86_64")]
-use kernel_hal::context::GeneralRegs;
+use arch::handler_user_trap;
 
 /// Create and run main Linux process
 pub fn run(args: Vec<String>, envs: Vec<String>, rootfs: Arc<dyn FileSystem>) -> Arc<Process> {
@@ -99,132 +105,4 @@ async fn new_thread(thread: CurrentThread) {
 
 fn thread_fn(thread: CurrentThread) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
     Box::pin(new_thread(thread))
-}
-
-async fn handler_user_trap(thread: &CurrentThread, cx: &mut UserContext) -> ZxResult {
-    let pid = thread.proc().id();
-
-    #[cfg(target_arch = "x86_64")]
-    match cx.trap_num {
-        0x100 => handle_syscall(thread, &mut cx.general).await,
-        0x20..=0xff => {
-            kernel_hal::interrupt::handle_irq(cx.trap_num);
-            // TODO: configurable
-            if cx.trap_num == 0xf1 {
-                kernel_hal::thread::yield_now().await;
-            }
-        }
-        0xe => {
-            let (vaddr, flags) = kernel_hal::context::fetch_page_fault_info(cx.error_code);
-            warn!(
-                "page fault from user mode @ {:#x}({:?}), pid={}",
-                vaddr, flags, pid
-            );
-            let vmar = thread.proc().vmar();
-            if let Err(err) = vmar.handle_page_fault(vaddr, flags) {
-                error!(
-                    "Failed to handle page Fault from user mode @ {:#x}({:?}): {:?}\n{:#x?}",
-                    vaddr, flags, err, cx
-                );
-                return Err(err);
-            }
-        }
-        _ => {
-            error!("not supported interrupt from user mode. {:#x?}", cx);
-            return Err(ZxError::NOT_SUPPORTED);
-        }
-    }
-
-    // UserContext
-    #[cfg(target_arch = "riscv64")]
-    {
-        let trap_num = kernel_hal::context::fetch_trap_num(&cx);
-        let is_interrupt = ((trap_num >> (core::mem::size_of::<usize>() * 8 - 1)) & 1) == 1;
-        let trap_num = trap_num & 0xfff;
-        if is_interrupt {
-            kernel_hal::interrupt::handle_irq(trap_num);
-            // Timer
-            if trap_num == 5 {
-                kernel_hal::thread::yield_now().await;
-            }
-        } else {
-            match trap_num {
-                // syscall
-                8 => handle_syscall(thread, cx).await,
-                // PageFault
-                12 | 13 | 15 => {
-                    let (vaddr, flags) = kernel_hal::context::fetch_page_fault_info(trap_num);
-                    warn!(
-                        "page fault from user mode @ {:#x}({:?}), pid={}",
-                        vaddr, flags, pid
-                    );
-                    let vmar = thread.proc().vmar();
-                    if let Err(err) = vmar.handle_page_fault(vaddr, flags) {
-                        error!(
-                            "Failed to handle page Fault from user mode @ {:#x}({:?}): {:?}\n{:#x?}",
-                            vaddr, flags, err, cx
-                        );
-                        return Err(err);
-                    }
-                }
-                _ => {
-                    error!(
-                        "not supported pid: {} exception {} from user mode. {:#x?}",
-                        pid, trap_num, cx
-                    );
-                    return Err(ZxError::NOT_SUPPORTED);
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// syscall handler entry
-#[cfg(target_arch = "x86_64")]
-async fn handle_syscall(thread: &CurrentThread, regs: &mut GeneralRegs) {
-    trace!("syscall: {:#x?}", regs);
-    let num = regs.rax as u32;
-    let args = [regs.rdi, regs.rsi, regs.rdx, regs.r10, regs.r8, regs.r9];
-    let mut syscall = Syscall {
-        thread,
-        #[cfg(feature = "std")]
-        syscall_entry: kernel_hal::context::syscall_entry as usize,
-        #[cfg(not(feature = "std"))]
-        syscall_entry: 0,
-        thread_fn,
-        regs,
-    };
-    regs.rax = syscall.syscall(num, args).await as usize;
-}
-
-#[cfg(target_arch = "riscv64")]
-async fn handle_syscall(thread: &CurrentThread, cx: &mut UserContext) {
-    trace!("syscall: {:#x?}", cx.general);
-    let num = cx.general.a7 as u32;
-    let args = [
-        cx.general.a0,
-        cx.general.a1,
-        cx.general.a2,
-        cx.general.a3,
-        cx.general.a4,
-        cx.general.a5,
-    ];
-    // add before fork
-    cx.sepc += 4;
-
-    //注意, 此时的regs没有原context所有权，故无法通过此regs修改寄存器
-    //let regs = &mut (cx.general as GeneralRegs);
-
-    let mut syscall = Syscall {
-        thread,
-        #[cfg(feature = "std")]
-        syscall_entry: kernel_hal::context::syscall_entry as usize,
-        #[cfg(not(feature = "std"))]
-        syscall_entry: 0,
-        context: cx,
-        thread_fn,
-    };
-    cx.general.a0 = syscall.syscall(num, args).await as usize;
 }


### PR DESCRIPTION
- Add `arch` module in `linux-loader` to remove heavy used #[cfg(target_arch = ...)] .
- Replace some magic numbers in `linux-loader`.