### PR TITLE
Bug fix: multi-core boot will dead-lock in qemu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.log
 Cargo.lock
 
+/toolchain
 /rootfs
 /riscv_rootfs
 /prebuilt/linux/alpine*

--- a/drivers/src/irq/riscv_intc.rs
+++ b/drivers/src/irq/riscv_intc.rs
@@ -66,7 +66,7 @@ impl Scheme for Intc {
     }
 
     fn handle_irq(&self, cause: usize) {
-        info!("intc handle irq, cause {}", cause);
+        trace!("intc handle irq, cause {}", cause);
         self.with_handler(cause, |opt| {
             if let Some(h) = opt.get() {
                 h();

--- a/kernel-hal/src/bare/arch/riscv/drivers.rs
+++ b/kernel-hal/src/bare/arch/riscv/drivers.rs
@@ -73,6 +73,12 @@ pub(super) fn init() -> DeviceResult {
         }
     }
 
+    #[cfg(feature = "loopback")]
+    {
+        use crate::net;
+        net::init();
+    }
+
     Ok(())
 }
 
@@ -92,21 +98,6 @@ pub(super) fn intc_init() -> DeviceResult {
     )?;
     irq.unmask(ScauseIntCode::SupervisorSoft as _)?;
     irq.unmask(ScauseIntCode::SupervisorTimer as _)?;
-
-    #[cfg(feature = "graphic")]
-    if let Some(display) = drivers::all_display().first() {
-        crate::console::init_graphic_console(display.clone());
-        if display.need_flush() {
-            // TODO: support nested interrupt to render in time
-            crate::thread::spawn(crate::common::future::DisplayFlushFuture::new(display, 30));
-        }
-    }
-
-    #[cfg(feature = "loopback")]
-    {
-        use crate::net;
-        net::init();
-    }
 
     Ok(())
 }

--- a/kernel-hal/src/bare/arch/riscv/mod.rs
+++ b/kernel-hal/src/bare/arch/riscv/mod.rs
@@ -71,5 +71,4 @@ pub fn secondary_init() {
         .find("riscv-plic")
         .expect("IRQ device 'riscv-plic' not initialized!");
     plic.init_hart();
-    // timer::init();
 }

--- a/zCore/src/main.rs
+++ b/zCore/src/main.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(feature = "libos"), no_std)]
 #![feature(lang_items)]
 #![feature(core_intrinsics)]
-// #![deny(warnings)] // comment this on develop
+#![deny(warnings)]
 
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -55,6 +55,7 @@ fn primary_main(config: kernel_hal::KernelConfig) {
     }
 }
 
+#[cfg(not(feature = "libos"))]
 fn secondary_main() -> ! {
     while !STARTED.load(Ordering::SeqCst) {}
     // Don't print anything between previous line and next line.


### PR DESCRIPTION
* bug fix: update `kernel-sync` which fixing dead-lock when boot with `smp := 4`
* bug fix: net::init() should not be called in secondary_init()
* comment: delete some unused log.