### PR TITLE
Fix nanosleep duration

### DIFF
--- a/linux-object/src/time.rs
+++ b/linux-object/src/time.rs
@@ -188,5 +188,5 @@ impl From<usize> for ClockFlags {
 /// nanosleep
 pub async fn nanosleep(dur: Duration) {
     use kernel_hal::thread;
-    thread::sleep_until(dur).await;
+    thread::sleep_until(timer::timer_now() + dur).await;
 }


### PR DESCRIPTION
Fix a tiny sleep bug: change to sleep deadline instead of duration.