### PR TITLE
Fix TCP connection stuck and nanosleep fault

### DIFF
--- a/drivers/src/net/rtlx.rs
+++ b/drivers/src/net/rtlx.rs
@@ -1,7 +1,6 @@
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::sync::Arc;
-// use alloc::vec;
 use alloc::vec::Vec;
 use lock::Mutex;
 
@@ -12,11 +11,8 @@ use smoltcp::time::Instant;
 use smoltcp::wire::*;
 use smoltcp::Result;
 
-use super::realtek::rtl8211f;
-use super::realtek::rtl8211f::RTL8211F;
-use super::ProviderImpl;
-use super::PAGE_SIZE;
-//use kernel_hal::drivers::{Driver, DeviceType, NetDriver, DRIVERS, NET_DRIVERS, SOCKETS};
+use super::realtek::rtl8211f::{self, RTL8211F};
+use super::{timer_now_as_micros, ProviderImpl, PAGE_SIZE};
 
 use crate::net::get_sockets;
 use crate::scheme::{NetScheme, Scheme};
@@ -48,7 +44,7 @@ impl Scheme for RTLxInterface {
 
         let handle_tx_rx = 3;
         if status == handle_tx_rx {
-            let timestamp = Instant::from_millis(0);
+            let timestamp = Instant::from_micros(timer_now_as_micros() as i64);
             let sockets = get_sockets();
             let mut sockets = sockets.lock();
 
@@ -81,7 +77,7 @@ impl NetScheme for RTLxInterface {
     }
 
     fn poll(&self) -> DeviceResult {
-        let timestamp = Instant::from_millis(0);
+        let timestamp = Instant::from_micros(timer_now_as_micros() as i64);
         let sockets = get_sockets();
         let mut sockets = sockets.lock();
         match self.iface.lock().poll(&mut sockets, timestamp) {

--- a/kernel-hal/src/drivers.rs
+++ b/kernel-hal/src/drivers.rs
@@ -186,4 +186,10 @@ mod drivers_ffi {
     extern "C" fn drivers_virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
         vaddr - KCONFIG.phys_to_virt_offset
     }
+
+    use crate::hal_fn::timer::timer_now;
+    #[no_mangle]
+    extern "C" fn drivers_timer_now_as_micros() -> u64 {
+        timer_now().as_micros() as _
+    }
 }

--- a/linux-object/src/time.rs
+++ b/linux-object/src/time.rs
@@ -184,9 +184,3 @@ impl From<usize> for ClockFlags {
         }
     }
 }
-
-/// nanosleep
-pub async fn nanosleep(dur: Duration) {
-    use kernel_hal::thread;
-    thread::sleep_until(dur).await;
-}

--- a/linux-syscall/src/task.rs
+++ b/linux-syscall/src/task.rs
@@ -7,6 +7,7 @@ use bitflags::bitflags;
 
 use kernel_hal::context::UserContextField;
 use linux_object::thread::{CurrentThreadExt, RobustList, ThreadExt};
+use linux_object::time::TimeSpec;
 use linux_object::{fs::INodeExt, loader::LinuxElfLoader};
 use zircon_object::vm::USER_STACK_PAGES;
 
@@ -369,8 +370,6 @@ impl Syscall<'_> {
     /// in the calling thread or that terminates the process.
     ///
     /// To represent a duration, see TimeSpec.
-
-    /* Deleted by 8278dc13 in Jan 28, 2022
     pub async fn sys_nanosleep(&self, req: UserInPtr<TimeSpec>) -> SysResult {
         info!("nanosleep: deadline={:?}", req);
         let duration = req.read()?.into();
@@ -378,7 +377,7 @@ impl Syscall<'_> {
         thread::sleep_until(timer::deadline_after(duration)).await;
         Ok(0)
     }
-    */
+
     //    pub fn sys_set_priority(&self, priority: usize) -> SysResult {
     //        let pid = thread::current().id();
     //        thread_manager().set_priority(pid, priority as u8);

--- a/linux-syscall/src/time.rs
+++ b/linux-syscall/src/time.rs
@@ -104,15 +104,6 @@ impl Syscall<'_> {
         Ok(tick as usize)
     }
 
-    /// Allows the calling thread to sleep for
-    /// an interval specified with nanosecond precision
-    pub async fn sys_nanosleep(&self, req: UserInPtr<TimeSpec>) -> SysResult {
-        info!("nanosleep: deadline={:?}", req);
-        let duration = req.read()?.into();
-        nanosleep(duration).await;
-        Ok(0)
-    }
-
     /// clock nanosleep
     pub async fn sys_clock_nanosleep(
         &self,
@@ -121,41 +112,39 @@ impl Syscall<'_> {
         req: UserInPtr<TimeSpec>,
         rem: UserOutPtr<TimeSpec>,
     ) -> SysResult {
-        warn!(
-            "clock_nanosleep: clockid={:?},flags={:?},req={:?},，rem={:?}",
+        info!(
+            "clock_nanosleep: clockid={:?}, flags={:?}, req={:?}, rem={:?}",
             clockid,
             flags,
             req.read()?,
             rem
         );
         use core::time::Duration;
+        use kernel_hal::{thread, timer};
         let duration: Duration = req.read()?.into();
         let clockid = ClockId::from(clockid);
         let flags = ClockFlags::from(flags);
-        warn!("clockid={:?},flags={:?}", clockid, flags,);
+        info!("clockid={:?}, flags={:?}", clockid, flags,);
         match clockid {
             ClockId::ClockRealTime => {
                 match flags {
                     ClockFlags::ZeroFlag => {
-                        nanosleep(duration).await;
+                        thread::sleep_until(timer::deadline_after(duration)).await;
                     }
                     ClockFlags::TimerAbsTime => {
                         // 目前统一由nanosleep代替了、之后再修改
-                        nanosleep(duration).await;
+                        thread::sleep_until(timer::deadline_after(duration)).await;
                     }
                 }
             }
-            ClockId::ClockMonotonic => {
-                match flags {
-                    ClockFlags::ZeroFlag => {
-                        nanosleep(duration).await;
-                    }
-                    ClockFlags::TimerAbsTime => {
-                        // 目前统一由nanosleep代替了、之后再修改
-                        nanosleep(duration).await;
-                    }
+            ClockId::ClockMonotonic => match flags {
+                ClockFlags::ZeroFlag => {
+                    thread::sleep_until(timer::deadline_after(duration)).await;
                 }
-            }
+                ClockFlags::TimerAbsTime => {
+                    thread::sleep_until(timer::deadline_after(duration)).await;
+                }
+            },
             ClockId::ClockProcessCpuTimeId => {}
             ClockId::ClockThreadCpuTimeId => {}
             ClockId::ClockMonotonicRaw => {}


### PR DESCRIPTION
TCP connection occurred that segment not in receive window, 
It will send challenge ACK. and then the connection stuck;
The smoltcp ACK timer made the connection stuck in network congestion,
After analysis, this problem was caused by clock driver offer;

Fix nanosleep fault;
