### PR TITLE
增加两个命令，以不同级别清理目录

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,17 @@ doc:
 clean:
 	cargo clean
 	rm -rf rootfs
-	rm -rf ignored/target
 	rm -rf zCore/disk
 	find zCore -maxdepth 1 -name "*.img" -delete
+	find zCore -maxdepth 1 -name "*.bin" -delete
+
+# delete targets, including those that are large and compile slowly
+cleanup: clean
+	rm -rf ignored/target
+
+# delete everything, including origin files that are downloaded directly
+clean-everything: clean
+	rm -rf ignored
 
 # rt-test:
 # 	cd rootfs/x86_64 && git clone https://kernel.googlesource.com/pub/scm/linux/kernel/git/clrkwllms/rt-tests --depth 1

--- a/xtask/src/command/mod.rs
+++ b/xtask/src/command/mod.rs
@@ -129,7 +129,7 @@ mod m {
                 }
             }
 
-            impl super::CommandExt for $ty {}
+            impl $crate::command::CommandExt for $ty {}
         };
     }
 

--- a/xtask/src/linux/mod.rs
+++ b/xtask/src/linux/mod.rs
@@ -78,7 +78,7 @@ impl LinuxRootfs {
 
     /// 指定架构的 rootfs 路径。
     #[inline]
-    fn path(&self) -> PathBuf {
+    pub fn path(&self) -> PathBuf {
         PROJECT_DIR.join("rootfs").join(self.0.name())
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,7 +22,6 @@ mod linux;
 
 use arch::{Arch, ArchArg};
 use build::{AsmArgs, GdbArgs, QemuArgs};
-use command::{dir, download::wget, Cargo, CommandExt, Ext, Git, Make, Tar};
 use errors::XError;
 use linux::LinuxRootfs;
 
@@ -61,34 +60,33 @@ enum Commands {
     Setup,
     /// Update rustup and cargo.
     UpdateAll,
-    /// Check style
     CheckStyle,
 
-    /// Build rootfs
+    /// Build rootfs.
     Rootfs(ArchArg),
-    /// Put musl libs into rootfs
+    /// Put musl libs into rootfs.
     MuslLibs(ArchArg),
-    /// Put opencv libs into rootfs
+    /// Put opencv libs into rootfs.
     Opencv(ArchArg),
-    /// Put ffmpeg libs into rootfs
+    /// Put ffmpeg libs into rootfs.
     Ffmpeg(ArchArg),
-    /// Put libc test into rootfs
+    /// Put libc test into rootfs.
     LibcTest(ArchArg),
-    /// Put other test into rootfs
+    /// Put other test into rootfs.
     OtherTest(ArchArg),
-    /// Build image
+    /// Build image.
     Image(ArchArg),
 
-    /// Build rootfs for libos mode and put libc test in
+    /// Build rootfs for libos mode and put libc test inside.
     LibosLibcTest,
-    /// Run in Linux libos mode
+    /// Run user program in Linux libos mode.
     LinuxLibos(LinuxLibosArg),
 
-    /// Dump asm of kernel
+    /// Dump asm of kernel.
     Asm(AsmArgs),
-    /// Run zCore in qemu
+    /// Run zCore in qemu.
     Qemu(QemuArgs),
-    /// Launch GDB
+    /// Launch GDB.
     Gdb(GdbArgs),
 }
 
@@ -139,10 +137,10 @@ fn main() {
         Image(arg) => arg.linux_rootfs().image(),
 
         LibosLibcTest => {
-            libos_rootfs(true);
-            libos_libc_test();
+            libos::rootfs(true);
+            libos::put_libc_test();
         }
-        LinuxLibos(arg) => linux_libos(arg.args),
+        LinuxLibos(arg) => libos::linux_run(arg.args),
 
         Asm(args) => args.asm(),
         Qemu(args) => args.qemu(),
@@ -152,6 +150,7 @@ fn main() {
 
 /// 初始化 LFS。
 fn make_git_lfs() {
+    use crate::command::{CommandExt, Git};
     if !Git::lfs()
         .arg("version")
         .as_mut()
@@ -166,11 +165,13 @@ fn make_git_lfs() {
 
 /// 更新子项目。
 fn git_submodule_update(init: bool) {
+    use crate::command::{CommandExt, Git};
     Git::submodule_update(init).invoke();
 }
 
 /// 更新工具链和依赖。
 fn update_all() {
+    use crate::command::{Cargo, CommandExt, Ext};
     git_submodule_update(false);
     Ext::new("rustup").arg("update").invoke();
     Cargo::update().invoke();
@@ -178,6 +179,7 @@ fn update_all() {
 
 /// 设置 git 代理。
 fn set_git_proxy(global: bool, port: u16) {
+    use crate::command::{CommandExt, Git};
     let dns = fs::read_to_string("/etc/resolv.conf")
         .unwrap()
         .lines()
@@ -194,6 +196,7 @@ fn set_git_proxy(global: bool, port: u16) {
 
 /// 移除 git 代理。
 fn unset_git_proxy(global: bool) {
+    use crate::command::{CommandExt, Git};
     Git::config(global)
         .args(&["--unset", "http.proxy"])
         .invoke();
@@ -205,6 +208,7 @@ fn unset_git_proxy(global: bool) {
 
 /// 风格检查。
 fn check_style() {
+    use crate::command::{Cargo, CommandExt, Make};
     println!("Check workspace");
     Cargo::fmt().arg("--all").arg("--").arg("--check").invoke();
     Cargo::clippy().all_features().invoke();
@@ -234,42 +238,55 @@ fn check_style() {
         .invoke();
 }
 
-fn libos_rootfs(clear: bool) {
-    // 下载
-    const URL: &str =
-        "https://github.com/YdrMaster/zCore/releases/download/dev-busybox/rootfs-libos.tar.gz";
-    let origin = ARCHS.join("libos").join("rootfs-libos.tar.gz");
-    dir::create_parent(&origin).unwrap();
-    wget(URL, &origin);
-    // 解压
-    let target = TARGET.join("libos");
-    fs::create_dir_all(&target).unwrap();
-    Tar::xf(origin.as_os_str(), Some(&target)).invoke();
-    // 拷贝
-    const ROOTFS: &str = "rootfs/libos";
-    if clear {
-        dir::clear(ROOTFS).unwrap();
+mod libos {
+    use crate::{
+        arch::Arch,
+        command::{dir, download::wget, Cargo, CommandExt, Tar},
+        linux::LinuxRootfs,
+        ARCHS, TARGET,
+    };
+    use std::fs;
+
+    /// 部署 libos 使用的 rootfs。
+    pub(super) fn rootfs(clear: bool) {
+        // 下载
+        const URL: &str =
+            "https://github.com/YdrMaster/zCore/releases/download/dev-busybox/rootfs-libos.tar.gz";
+        let origin = ARCHS.join("libos").join("rootfs-libos.tar.gz");
+        dir::create_parent(&origin).unwrap();
+        wget(URL, &origin);
+        // 解压
+        let target = TARGET.join("libos");
+        fs::create_dir_all(&target).unwrap();
+        Tar::xf(origin.as_os_str(), Some(&target)).invoke();
+        // 拷贝
+        const ROOTFS: &str = "rootfs/libos";
+        if clear {
+            dir::clear(ROOTFS).unwrap();
+        }
+        dircpy::copy_dir(target.join("rootfs"), ROOTFS).unwrap();
     }
-    dircpy::copy_dir(target.join("rootfs"), ROOTFS).unwrap();
-}
 
-fn libos_libc_test() {
-    const TARGET: &str = "rootfs/libos/libc-test";
-    LinuxRootfs::new(Arch::X86_64).put_libc_test();
-    dir::clear(TARGET).unwrap();
-    dircpy::copy_dir("rootfs/x86_64/libc-test", TARGET).unwrap();
-}
+    /// 将 x86_64 的 libc-test 复制到 libos。
+    pub(super) fn put_libc_test() {
+        const TARGET: &str = "rootfs/libos/libc-test";
+        let x86_64 = LinuxRootfs::new(Arch::X86_64);
+        x86_64.put_libc_test();
+        dir::clear(TARGET).unwrap();
+        dircpy::copy_dir(x86_64.path().join("libc-test"), TARGET).unwrap();
+    }
 
-/// libos 模式执行应用程序。
-fn linux_libos(args: String) {
-    println!("{}", std::env!("OUT_DIR"));
-    libos_rootfs(false);
-    // 启动！
-    Cargo::run()
-        .package("zcore")
-        .release()
-        .features(true, ["linux"])
-        .arg("--")
-        .args(args.split_whitespace())
-        .invoke()
+    /// libos 模式执行应用程序。
+    pub(super) fn linux_run(args: String) {
+        println!("{}", std::env!("OUT_DIR"));
+        rootfs(false);
+        // 启动！
+        Cargo::run()
+            .package("zcore")
+            .release()
+            .features(true, ["linux"])
+            .arg("--")
+            .args(args.split_whitespace())
+            .invoke()
+    }
 }


### PR DESCRIPTION
解决 #330 的一部分

- `make clean`: 清理 rust 编译产物和拷贝构造的目录
- `make cleanup`: 清理所有不需要下载的东西，包括编译很慢的第三方库
- `make clean-everything`: 清理所有东西，包括需要下载的