### PR TITLE
fix(zCore): riscv 上内核统一映射到虚存最后一页

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,7 +2412,6 @@ dependencies = [
  "dtb-walker",
  "executor",
  "kernel-hal",
- "lazy_static",
  "linux-object",
  "lock",
  "log",
@@ -2424,6 +2423,7 @@ dependencies = [
  "rcore-fs-sfs",
  "riscv 0.8.0",
  "sbi-rt",
+ "spin 0.9.3",
  "zcore-loader",
  "zircon-object",
 ]

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -53,7 +53,7 @@ loopback = ["kernel-hal/loopback"]
 [dependencies]
 log = "0.4"
 cfg-if = "1.0"
-lazy_static = { version = "1.4", features = ["spin_no_std"] }
+spin = "0.9.3"
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
 kernel-hal = { path = "../kernel-hal", default-features = false }
 zcore-loader = { path = "../loader", default-features = false }

--- a/zCore/build.rs
+++ b/zCore/build.rs
@@ -2,10 +2,11 @@ use std::{env, fs::File, io::Write};
 
 fn main() {
     if env::var("TARGET").unwrap().contains("riscv64") {
+        // 不同的 BOOTLOADER 会将内核放在不同的位置
         let kernel_base_addr = if env::var("PLATFORM").map_or(false, |p| p.contains("d1")) {
-            0xffffffffc0100000usize
+            0xffff_ffff_c010_0000usize
         } else {
-            0xffffffff80200000usize
+            0xffff_ffff_c020_0000usize
         };
 
         File::create("src/platform/riscv/linker.ld")

--- a/zCore/src/memory.rs
+++ b/zCore/src/memory.rs
@@ -1,6 +1,6 @@
 //! Define physical frame allocation and dynamic memory allocation.
 
-use super::platform::consts::*;
+use super::platform::consts;
 use bitmap_allocator::BitAlloc;
 use core::ops::Range;
 use kernel_hal::PhysAddr;
@@ -21,11 +21,11 @@ const PAGE_SIZE: usize = 4096;
 static FRAME_ALLOCATOR: Mutex<FrameAlloc> = Mutex::new(FrameAlloc::DEFAULT);
 
 fn phys_addr_to_frame_idx(addr: PhysAddr) -> usize {
-    (addr - PHYS_MEMORY_BASE) / PAGE_SIZE
+    (addr - consts::phys_memory_base()) / PAGE_SIZE
 }
 
 fn frame_idx_to_phys_addr(idx: usize) -> PhysAddr {
-    idx * PAGE_SIZE + PHYS_MEMORY_BASE
+    idx * PAGE_SIZE + consts::phys_memory_base()
 }
 
 pub fn init_frame_allocator(regions: &[Range<PhysAddr>]) {
@@ -89,7 +89,7 @@ cfg_if! {
         /// Initialize the global heap allocator.
         pub fn init_heap() {
             const MACHINE_ALIGN: usize = core::mem::size_of::<usize>();
-            const HEAP_BLOCK: usize = KERNEL_HEAP_SIZE / MACHINE_ALIGN;
+            const HEAP_BLOCK: usize = consts::KERNEL_HEAP_SIZE / MACHINE_ALIGN;
             static mut HEAP: [usize; HEAP_BLOCK] = [0; HEAP_BLOCK];
             let heap_start = unsafe { HEAP.as_ptr() as usize };
             unsafe {
@@ -99,7 +99,7 @@ cfg_if! {
             }
             info!(
                 "Heap init end: {:#x?}",
-                heap_start..heap_start + KERNEL_HEAP_SIZE
+                heap_start..heap_start + consts::KERNEL_HEAP_SIZE
             );
         }
 
@@ -154,6 +154,8 @@ mod rvm_extern_fn {
 
     #[rvm::extern_fn(phys_to_virt)]
     fn rvm_phys_to_virt(paddr: usize) -> usize {
+        // 示意，这个常量已经没了
+        // pub const PHYSICAL_MEMORY_OFFSET: usize = KERNEL_OFFSET - PHYS_MEMORY_BASE;
         paddr + PHYSICAL_MEMORY_OFFSET
     }
 

--- a/zCore/src/platform/aarch64/consts.rs
+++ b/zCore/src/platform/aarch64/consts.rs
@@ -1,4 +1,8 @@
 // aarch64
 
-pub use kernel_hal::arch::config::PHYS_MEMORY_BASE;
 pub const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024; // 32 MB
+
+#[inline]
+pub fn phys_memory_base() -> usize {
+    kernel_hal::arch::config::PHYS_MEMORY_BASE
+}

--- a/zCore/src/platform/libos/consts.rs
+++ b/zCore/src/platform/libos/consts.rs
@@ -1,1 +1,4 @@
-pub const PHYS_MEMORY_BASE: usize = 0;
+#[inline]
+pub fn phys_memory_base() -> usize {
+    0
+}

--- a/zCore/src/platform/riscv/consts.rs
+++ b/zCore/src/platform/riscv/consts.rs
@@ -1,16 +1,74 @@
 // RISCV
 
-cfg_if! {
-    if #[cfg(feature = "board-qemu")] {
-        pub const KERNEL_OFFSET: usize = 0xFFFF_FFFF_8000_0000;
-        pub const PHYS_MEMORY_BASE: usize = 0x8000_0000;
-    } else if #[cfg(feature = "board-d1")] {
-        pub const KERNEL_OFFSET: usize = 0xFFFF_FFFF_C000_0000;
-        pub const PHYS_MEMORY_BASE: usize = 0x4000_0000;
+/// 内核堆容量。
+pub const KERNEL_HEAP_SIZE: usize = 80 * 1024 * 1024; // 80 MB
+
+/// 内核每个硬件线程的栈页数。
+pub const STACK_PAGES_PER_HART: usize = 32;
+
+/// 最大的对称多核硬件线程数量。
+pub const MAX_HART_NUM: usize = 8;
+
+#[inline]
+pub fn phys_memory_base() -> usize {
+    kernel_mem_info().paddr_base
+}
+
+use spin::Once;
+
+/// 内核位置信息
+pub struct KernelMemInfo {
+    /// 内核所在物理 GiB 页的起始地址。
+    ///
+    /// 这个地址也被视物理地址空间中主存的起始地址。
+    pub paddr_base: usize,
+
+    /// 内核所在虚拟 GiB 页的起始地址。
+    ///
+    /// 实际上是 Sv39 方案虚存的最后一个 GiB 页的起始地址。
+    pub vaddr_base: usize,
+}
+
+impl KernelMemInfo {
+    /// 初始化物理内存信息。
+    ///
+    /// # Safety
+    ///
+    /// 这个函数必须在 `pc` 仍在物理地址空间时调用！
+    ///
+    /// 除此之外，其正确性还依赖下列条件：
+    ///
+    /// 1. 主存的物理地址对齐到 1 GiB
+    /// 2. 内核在主存上的位置在主存的第 1 个 GiB 内
+    /// 3. 内核的链接地址与内核的物理地址在一个 GiB 内的偏移一致
+    unsafe fn new() -> Self {
+        // 这个函数必须在 pc 仍在物理地址上时调用！
+        let pc: usize;
+        core::arch::asm!("auipc {}, 0", out(reg) pc);
+        const GIB_MASK: usize = !((1 << 30) - 1);
+        Self {
+            // 由于条件 2，内核物理地址所在的 GiB 页地址就是主存起始地址
+            paddr_base: pc & GIB_MASK,
+            // 内核链接位置所在 GiB 页的地址
+            // 这个值实际上整个虚存空间上最后一个 GiB 页的地址，因此是一个常量
+            vaddr_base: usize::MAX & GIB_MASK,
+        }
+    }
+
+    /// 计算内核虚存空间到物理地址空间的偏移。
+    pub fn offset(&self) -> usize {
+        self.vaddr_base - self.paddr_base
     }
 }
 
-pub const PHYSICAL_MEMORY_OFFSET: usize = KERNEL_OFFSET - PHYS_MEMORY_BASE;
-pub const KERNEL_HEAP_SIZE: usize = 80 * 1024 * 1024; // 80 MB
-pub const STACK_PAGES_PER_HART: usize = 32;
-pub const MAX_HART_NUM: usize = 8;
+static KERNEL_MEM_INFO: Once<KernelMemInfo> = Once::new();
+
+#[inline]
+pub fn kernel_mem_info() -> &'static KernelMemInfo {
+    KERNEL_MEM_INFO.wait()
+}
+
+#[inline]
+pub(super) unsafe fn kernel_mem_probe() -> &'static KernelMemInfo {
+    KERNEL_MEM_INFO.call_once(|| KernelMemInfo::new())
+}

--- a/zCore/src/platform/x86/consts.rs
+++ b/zCore/src/platform/x86/consts.rs
@@ -1,4 +1,8 @@
 // x86_64
 
-pub const PHYS_MEMORY_BASE: usize = 0;
 pub const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024; // 16 MB
+
+#[inline]
+pub fn phys_memory_base() -> usize {
+    0
+}


### PR DESCRIPTION
部分解决内核虚地址在不同硬件需要映射到不同位置的问题，并且看到了完整支持内核重定位的可能性。

现在内核会在启动时定位自己在物理内存上的位置，而在虚存上的位置是一个常量。

Signed-off-by: YdrMaster <ydrml@hotmail.com>