### PR TITLE
解决 feature stablization 导致的编译问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
 dependencies = [
  "atty",
  "bitflags",
@@ -541,9 +541,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtb-walker"
-version = "0.1.3"
+version = "0.2.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3a45c340447805972e5f53bf10e7118d8333bfb779f9c0ba7ec6ea30d40cd8"
+checksum = "c85a84940f2e41c8907a4903c9991ab5dba8fa386386f2f91b94c1d678d8f423"
 
 [[package]]
 name = "either"
@@ -1689,18 +1689,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2366,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "x86_64"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958cd5cb28e720db2f59ee9dc4235b5f82a183d079fb0e6caf43ad074cfdc66a"
+checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
  "bitflags",
@@ -2398,7 +2398,7 @@ dependencies = [
 name = "xtask"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.8",
+ "clap 3.2.10",
  "command-ext",
  "dircpy",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.10"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
@@ -518,6 +518,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "d1-pac"
+version = "0.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e867eeb4de0ab9c53582fc77a0afc1ca88784ac85b7b6e77a468c44c6e3145b"
+dependencies = [
+ "bare-metal",
+ "riscv 0.8.0",
+ "vcell",
+]
+
+[[package]]
 name = "device_tree"
 version = "1.0.3"
 source = "git+https://github.com/rcore-os/device_tree-rs?rev=2f2e55f#2f2e55fb5238466747fef49d9ce0f59b2e808154"
@@ -541,9 +552,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtb-walker"
-version = "0.2.0-alpha.1"
+version = "0.2.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85a84940f2e41c8907a4903c9991ab5dba8fa386386f2f91b94c1d678d8f423"
+checksum = "da7c41cf8cee950296756ba4623e8d46acdbb75d3b663e4f9a4d78fcc6e43fa0"
 
 [[package]]
 name = "either"
@@ -615,7 +626,7 @@ dependencies = [
  "log",
  "raw-cpuid 10.3.0",
  "riscv 0.8.0",
- "spin 0.9.3",
+ "spin 0.9.4",
  "tock-registers",
  "unicycle",
  "woke",
@@ -909,7 +920,7 @@ dependencies = [
  "bit_field",
  "bitflags",
  "log",
- "spin 0.9.3",
+ "spin 0.9.4",
  "volatile 0.3.0",
 ]
 
@@ -963,7 +974,7 @@ dependencies = [
  "riscv 0.8.0",
  "sbi-rt",
  "smoltcp",
- "spin 0.9.3",
+ "spin 0.9.4",
  "tempfile",
  "tock-registers",
  "trapframe",
@@ -1076,7 +1087,7 @@ dependencies = [
  "cortex-a",
  "raw-cpuid 10.3.0",
  "riscv 0.7.0",
- "spin 0.9.3",
+ "spin 0.9.4",
  "tock-registers",
  "x86_64",
 ]
@@ -1220,9 +1231,9 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "page-table"
@@ -1472,7 +1483,7 @@ source = "git+https://github.com/rcore-os/rcore-fs?rev=1a3246b#1a3246b1d3754f414
 dependencies = [
  "filetime",
  "libc",
- "spin 0.9.3",
+ "spin 0.9.4",
  "winapi",
 ]
 
@@ -1482,7 +1493,7 @@ version = "0.1.0"
 source = "git+https://github.com/rcore-os/rcore-fs?rev=1a3246b#1a3246b1d3754f414817d72a6217fc7b6076ff30"
 dependencies = [
  "rcore-fs",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -1520,7 +1531,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rcore-fs",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -1530,7 +1541,7 @@ source = "git+https://github.com/rcore-os/rcore-fs?rev=1a3246b#1a3246b1d3754f414
 dependencies = [
  "log",
  "rcore-fs",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
@@ -1541,7 +1552,7 @@ dependencies = [
  "bitvec",
  "log",
  "rcore-fs",
- "spin 0.9.3",
+ "spin 0.9.4",
  "static_assertions",
 ]
 
@@ -1553,7 +1564,7 @@ dependencies = [
  "bitvec",
  "log",
  "rcore-fs",
- "spin 0.9.3",
+ "spin 0.9.4",
  "static_assertions",
 ]
 
@@ -1640,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "same-file"
@@ -1779,9 +1790,9 @@ checksum = "13287b4da9d1207a4f4929ac390916d64eacfe236a487e9a9f5b3be392be5162"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -1984,9 +1995,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
@@ -2055,6 +2066,12 @@ dependencies = [
  "ctor",
  "version_check",
 ]
+
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "vcpkg"
@@ -2398,7 +2415,7 @@ dependencies = [
 name = "xtask"
 version = "0.1.0"
 dependencies = [
- "clap 3.2.10",
+ "clap 3.2.12",
  "command-ext",
  "dircpy",
  "lazy_static",
@@ -2434,7 +2451,7 @@ dependencies = [
  "rcore-fs-sfs",
  "riscv 0.8.0",
  "sbi-rt",
- "spin 0.9.3",
+ "spin 0.9.4",
  "zcore-loader",
  "zircon-object",
 ]
@@ -2448,6 +2465,7 @@ dependencies = [
  "bitflags",
  "bitmap-allocator",
  "cfg-if 1.0.0",
+ "d1-pac",
  "device_tree",
  "isomorphic_drivers",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "heck"
@@ -883,7 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.2",
 ]
 
 [[package]]
@@ -1226,8 +1226,9 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "page-table"
-version = "0.0.1"
-source = "git+https://github.com/YdrMaster/page-table.git?rev=2c8e478#2c8e47884bc7e2df645578ba793664d807bb7dcf"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076fe7cacd321402293adfde95b1cc81e0a1dfc3e60c0cddcb29bf39c174e48"
 dependencies = [
  "cfg-if 1.0.0",
  "static_assertions",

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -11,6 +11,7 @@ description = "Device drivers of zCore"
 graphic = ["rcore-console"]
 mock = ["async-std", "sdl2"]
 virtio = ["virtio-drivers"]
+board-d1 = ["d1-pac"]
 
 [dependencies]
 log = "0.4"
@@ -55,3 +56,4 @@ x86_64 = "0.14"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.8"
+d1-pac = { version = "0.0.23", optional = true }

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -56,4 +56,4 @@ x86_64 = "0.14"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.8"
-d1-pac = { version = "0.0.23", optional = true }
+d1-pac = { version = "0.0.24", optional = true }

--- a/drivers/src/builder/devicetree.rs
+++ b/drivers/src/builder/devicetree.rs
@@ -17,8 +17,6 @@
 //!
 //! Specification: <https://github.com/devicetree-org/devicetree-specification/releases/download/v0.3/devicetree-specification-v0.3.pdf>.
 
-use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
-
 use super::IoMapper;
 use crate::{
     utils::devicetree::{
@@ -26,6 +24,7 @@ use crate::{
     },
     Device, DeviceError, DeviceResult, VirtAddr,
 };
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 const MODULE: &str = "device-tree";
 
@@ -135,6 +134,7 @@ impl<M: IoMapper> DevicetreeDriverBuilder<M> {
     }
 }
 
+#[allow(dead_code)]
 #[allow(unused_imports)]
 #[allow(unused_variables)]
 #[allow(unreachable_code)]
@@ -258,9 +258,8 @@ impl<M: IoMapper> DevicetreeDriverBuilder<M> {
             c if c.contains("ns16550a") => {
                 Arc::new(unsafe { Uart16550Mmio::<u8>::new(base_vaddr?) })
             }
-            c if c.contains("allwinner,sun20i-uart") => {
-                Arc::new(unsafe { Uart16550Mmio::<u32>::new(base_vaddr?) })
-            }
+            #[cfg(feature = "board-d1")]
+            c if c.contains("allwinner,sun20i-uart") => Arc::new(UartAllwinner::new(base_vaddr?)),
             _ => return Err(DeviceError::NotSupported),
         });
 

--- a/drivers/src/uart/mod.rs
+++ b/drivers/src/uart/mod.rs
@@ -2,6 +2,8 @@
 
 mod buffered;
 mod uart_16550;
+#[cfg(feature = "board-d1")]
+mod uart_allwinner;
 #[cfg(target_arch = "aarch64")]
 mod uart_pl011;
 
@@ -10,5 +12,7 @@ pub use uart_16550::Uart16550Mmio;
 
 #[cfg(target_arch = "x86_64")]
 pub use uart_16550::Uart16550Pmio;
+#[cfg(feature = "board-d1")]
+pub use uart_allwinner::UartAllwinner;
 #[cfg(target_arch = "aarch64")]
 pub use uart_pl011::Pl011Uart;

--- a/drivers/src/uart/uart_allwinner.rs
+++ b/drivers/src/uart/uart_allwinner.rs
@@ -1,0 +1,110 @@
+﻿use crate::{
+    scheme::{impl_event_scheme, Scheme, UartScheme},
+    utils::EventListener,
+    DeviceResult, VirtAddr,
+};
+use d1_pac::uart;
+use spin::Mutex;
+
+pub struct UartAllwinner {
+    inner: Mutex<Inner>,
+    listener: EventListener,
+}
+
+impl_event_scheme!(UartAllwinner);
+
+impl UartAllwinner {
+    pub fn new(base: VirtAddr) -> Self {
+        let inner = Inner(base);
+        inner.init();
+        Self {
+            inner: Mutex::new(inner),
+            listener: EventListener::new(),
+        }
+    }
+}
+
+impl Scheme for UartAllwinner {
+    fn name(&self) -> &str {
+        "uart-allwinner"
+    }
+
+    fn handle_irq(&self, _irq_num: usize) {
+        self.listener.trigger(());
+    }
+}
+
+impl UartScheme for UartAllwinner {
+    fn try_recv(&self) -> DeviceResult<Option<u8>> {
+        self.inner.lock().try_recv()
+    }
+
+    fn send(&self, ch: u8) -> DeviceResult {
+        self.inner.lock().send(ch)
+    }
+}
+
+struct Inner(VirtAddr);
+
+impl Inner {
+    /// 初始化串口控制器
+    /// BAUD 115200
+    /// FIFO ON
+    fn init(&self) {
+        let block = self.block();
+        // disable interrupts
+        block.ier().reset();
+        // enable fifo
+        block.fcr().write(|w| w.fifoe().set_bit());
+        {
+            block.halt.write(|w| w.halt_tx().set_bit());
+            block.lcr.write(|w| w.dlab().set_bit());
+            // 13 for 115200
+            block.dll().write(|w| w.dll().variant(13));
+            block.dlh().write(|w| w.dlh().variant(0));
+            // no break | parity disabled | 1 stop bit | 8 data bits
+            block.lcr.write(|w| w.dls().eight());
+            #[rustfmt::skip]
+            block.halt.write(|w| w
+                .change_update().set_bit()
+                .chcfg_at_busy().set_bit());
+        }
+        // reset fifo
+        #[rustfmt::skip]
+        block.fcr().write(|w| w
+            .xfifor().set_bit()
+            .rfifor().set_bit()
+            .fifoe() .set_bit()
+        );
+        // uart mode
+        block.mcr.reset();
+        // enable interrupts
+        block.ier().write(|w| w.erbfi().set_bit());
+    }
+
+    /// 接收
+    fn try_recv(&self) -> DeviceResult<Option<u8>> {
+        let block = self.block();
+        if block.lsr.read().dr().bit_is_set() {
+            Ok(Some(block.rbr().read().bits() as _))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// 发送
+    fn send(&self, ch: u8) -> DeviceResult {
+        let block = self.block();
+        // 等待 FIFO 空位
+        while block.usr.read().tfnf().is_full() {
+            core::hint::spin_loop();
+        }
+        block.thr().write(|w| w.thr().variant(ch));
+        Ok(())
+    }
+
+    #[inline]
+    fn block(&self) -> &uart::RegisterBlock {
+        unsafe { &*(self.0 as *const _) }
+    }
+}

--- a/drivers/src/uart/uart_allwinner.rs
+++ b/drivers/src/uart/uart_allwinner.rs
@@ -4,7 +4,7 @@
     DeviceResult, VirtAddr,
 };
 use d1_pac::uart;
-use spin::Mutex;
+use lock::Mutex;
 
 pub struct UartAllwinner {
     inner: Mutex<Inner>,

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -66,7 +66,7 @@ executor = { git = "https://github.com/DeathWish5/PreemptiveScheduler", rev = "e
 # For riscv
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.8"
-dtb-walker = "0.1.3"
+dtb-walker = "0.2.0-alpha.1"
 sbi-rt = { git = "https://github.com/rustsbi/sbi-rt.git", rev = "6047ed5" }
 
 # For x86_64

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -20,7 +20,7 @@ libos = [
   "zcore-drivers/mock",
 ]
 graphic = ["zcore-drivers/graphic"]
-board-d1 = []
+board-d1 = ["zcore-drivers/board-d1"]
 link-user-img = []
 loopback = []
 

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -66,7 +66,7 @@ executor = { git = "https://github.com/DeathWish5/PreemptiveScheduler", rev = "e
 # For riscv
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.8"
-dtb-walker = "0.2.0-alpha.1"
+dtb-walker = "0.2.0-alpha.2"
 sbi-rt = { git = "https://github.com/rustsbi/sbi-rt.git", rev = "6047ed5" }
 
 # For x86_64

--- a/linux-object/src/lib.rs
+++ b/linux-object/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(warnings, unsafe_code, missing_docs)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::uninit_vec)]
-#![feature(untagged_unions)]
 
 #[macro_use]
 extern crate alloc;

--- a/linux-object/src/net/socket_address.rs
+++ b/linux-object/src/net/socket_address.rs
@@ -1,7 +1,6 @@
 // core
 
-use core::cmp::min;
-use core::mem::size_of;
+use core::{cmp::min, mem::size_of};
 
 // crate
 use crate::error::LxError;
@@ -33,6 +32,7 @@ pub union SockAddr {
 }
 
 /// missing documentation
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SockAddrIn {
     /// missing documentation
@@ -46,6 +46,7 @@ pub struct SockAddrIn {
 }
 
 /// missing documentation
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SockAddrUn {
     /// missing documentation
@@ -55,6 +56,7 @@ pub struct SockAddrUn {
 }
 
 /// missing documentation
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SockAddrLl {
     /// missing documentation
@@ -74,6 +76,7 @@ pub struct SockAddrLl {
 }
 
 /// missing documentation
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SockAddrNl {
     nl_family: u16,
@@ -83,6 +86,7 @@ pub struct SockAddrNl {
 }
 
 /// missing documentation
+#[derive(Clone, Copy)]
 #[repr(C)]
 pub struct SockAddrPlaceholder {
     /// missing documentation

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -78,7 +78,7 @@ buddy_system_allocator = "0.8"
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 r0 = "1"
 riscv = "0.8"
-dtb-walker = "0.1.3"
+dtb-walker = "0.2.0-alpha.1"
 page-table = "0.0.2"
 sbi-rt = { git = "https://github.com/rustsbi/sbi-rt.git", rev = "6047ed5" }
 

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -79,8 +79,8 @@ buddy_system_allocator = "0.8"
 r0 = "1"
 riscv = "0.8"
 dtb-walker = "0.1.3"
+page-table = "0.0.2"
 sbi-rt = { git = "https://github.com/rustsbi/sbi-rt.git", rev = "6047ed5" }
-page-table = { git = "https://github.com/YdrMaster/page-table.git", rev = "2c8e478" }
 
 # Bare-metal mode on x86_64
 [target.'cfg(all(target_os = "none", target_arch = "x86_64"))'.dependencies]

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -78,7 +78,7 @@ buddy_system_allocator = "0.8"
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 r0 = "1"
 riscv = "0.8"
-dtb-walker = "0.2.0-alpha.1"
+dtb-walker = "0.2.0-alpha.2"
 page-table = "0.0.2"
 sbi-rt = { git = "https://github.com/rustsbi/sbi-rt.git", rev = "6047ed5" }
 


### PR DESCRIPTION
- 升级页表库、设备树库和其他依赖
- 为 d1 提供基于 d1-pac 的专用串口驱动
- 为 Socket 类型增加 derive Copy，解决 union 安全性相关 feature 稳定引起的编译问题（[build#401](https://github.com/rcore-os/zCore/actions/runs/2683349582)）