### PR TITLE
[fix bug] Solve the problem that socket.exe testcase fails on D1 platform.

### DIFF
--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -11,6 +11,7 @@ description = "Device drivers of zCore"
 graphic = ["rcore-console"]
 mock = ["async-std", "sdl2"]
 virtio = ["virtio-drivers"]
+loopback = []
 
 [dependencies]
 log = "0.4"

--- a/drivers/src/builder/devicetree.rs
+++ b/drivers/src/builder/devicetree.rs
@@ -86,6 +86,7 @@ impl<M: IoMapper> DevicetreeDriverBuilder<M> {
                 match comp {
                     #[cfg(feature = "virtio")]
                     c if c.contains("virtio,mmio") => self.parse_virtio(node, props),
+                    #[cfg(not(feature = "loopback"))]
                     c if c.contains("allwinner,sunxi-gmac") => {
                         self.parse_ethernet(node, comp, props)
                     }

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -22,7 +22,7 @@ libos = [
 graphic = ["zcore-drivers/graphic"]
 board-d1 = []
 link-user-img = []
-loopback = []
+loopback = ["zcore-drivers/loopback"]
 
 [dependencies]
 log = "0.4"

--- a/kernel-hal/src/lib.rs
+++ b/kernel-hal/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(feature = "libos"), no_std)]
 #![cfg_attr(feature = "libos", feature(thread_id_value))]
 #![feature(doc_cfg)]
-#![feature(if_let_guard, let_chains)]
+#![feature(if_let_guard)]
 #![allow(clippy::uninit_vec)]
 #![deny(warnings)]
 


### PR DESCRIPTION
- 解决D1平台上socket.exe测例不通过的问题。
- 更新aarch64_bare和riscv64_d1两个平台的测例。