### PR TITLE
fix(xtask): libos模式运行需指定zcore的libos feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ cargo image --arch riscv64
 > **NOTICE** libos 模式只能执行单个应用程序，完成就会退出。
 
 ```bash
-cargo linux-libos --args /bin/busybox
+# 例如"/bin/busybox ls" 
+cargo linux-libos --args "/bin/busybox"
 ```
 
 ## 平台支持

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -464,7 +464,7 @@ mod libos {
         Cargo::run()
             .package("zcore")
             .release()
-            .features(true, ["linux"])
+            .features(true, ["linux", "libos"])
             .arg("--")
             .args(args.split_whitespace())
             .invoke()


### PR DESCRIPTION
按照readme里跑libos模式运行的时候报错，提示找不到依赖：
```
$ cargo linux-libos --args /bin/busybox
```

```plaintext
error[E0433]: failed to resolve: use of undeclared crate or module `x2apic`
  --> kernel-hal/src/bare/arch/x86_64/drivers.rs:36:9
   |
36 |     use x2apic::lapic::{TimerDivide, TimerMode};
   |         ^^^^^^ use of undeclared crate or module `x2apic`

error[E0433]: failed to resolve: use of undeclared crate or module `uefi`
 --> kernel-hal/src/bare/arch/x86_64/config.rs:3:5
  |
3 | use uefi::proto::console::gop::ModeInfo;
  |     ^^^^ use of undeclared crate or module `uefi`
```

看了一下发现是因为没有给zcore的feature里指定libos，加了以后运行正常。

顺便在文档里说明了一下如何给busybox传参数。