### PR TITLE
Refactor of the socket framework and fix the issue of UDP RTSP packet receiving

### DIFF
--- a/drivers/src/net/e1000.rs
+++ b/drivers/src/net/e1000.rs
@@ -82,7 +82,7 @@ impl NetScheme for E1000Interface {
         match self.iface.lock().poll(&mut sockets, timestamp) {
             Ok(p) => {
                 //SOCKET_ACTIVITY.notify_all();
-                info!("e1000 NetScheme poll: {:?}", p);
+                trace!("e1000 NetScheme poll: {:?}", p);
                 Ok(())
             }
             Err(err) => {
@@ -189,8 +189,8 @@ pub fn init(
     static mut ROUTES_STORAGE: [Option<(IpCidr, Route)>; 1] = [None; 1];
     let mut routes = unsafe { Routes::new(&mut ROUTES_STORAGE[..]) };
     routes.add_default_ipv4_route(default_v4_gw).unwrap();
-
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
+
     let iface = InterfaceBuilder::new(net_driver.clone())
         .ethernet_addr(ethernet_addr)
         .neighbor_cache(neighbor_cache)

--- a/drivers/src/net/mod.rs
+++ b/drivers/src/net/mod.rs
@@ -82,6 +82,7 @@ lazy_static::lazy_static! {
     Arc::new(Mutex::new(SocketSet::new(vec![])));
 }
 
+// 注意！这个容易出现死锁
 pub fn get_sockets() -> Arc<Mutex<SocketSet<'static>>> {
     SOCKETS.clone()
 }

--- a/drivers/src/net/realtek/rtl8211f.rs
+++ b/drivers/src/net/realtek/rtl8211f.rs
@@ -1250,8 +1250,8 @@ where
         info!("mac init, write TX_CTL0 {:#x}", value);
 
         let mut value: u32 = read_volatile((self.base + GETH_RX_CTL0) as *mut u32);
-        value |= 1 << 27; /* Enable CRC & IPv4 Header Checksum */
-        value |= 1 << 28; /* Automatic Pad/CRC Stripping */
+        value &= !(1 << 27); /* Disable CRC & IPv4 Header Checksum */
+        value &= !(1 << 28); /* Keep Pad/CRC */
         value |= 1 << 29; /* Jumbo Frame Enable */
         write_volatile((self.base + GETH_RX_CTL0) as *mut u32, value);
         info!("mac init, write RX_CTL0 {:#x}", value);

--- a/kernel-hal/src/bare/timer.rs
+++ b/kernel-hal/src/bare/timer.rs
@@ -24,6 +24,7 @@ hal_fn_impl! {
         }
 
         fn timer_set(deadline: Duration, callback: Box<dyn FnOnce(Duration) + Send + Sync>) {
+            debug!("Set timer at: {:?}", deadline);
             NAIVE_TIMER.lock().add(deadline, callback);
         }
 

--- a/linux-object/src/fs/file.rs
+++ b/linux-object/src/fs/file.rs
@@ -63,6 +63,21 @@ impl OpenFlags {
     }
 }
 
+bitflags::bitflags! {
+    pub struct PollEvents: u16 {
+        /// There is data to read.
+        const IN = 0x0001;
+        /// Writing is now possible.
+        const OUT = 0x0004;
+        /// Error condition (return only)
+        const ERR = 0x0008;
+        /// Hang up (return only)
+        const HUP = 0x0010;
+        /// Invalid request: fd not open (return only)
+        const INVAL = 0x0020;
+    }
+}
+
 /// file seek type
 #[derive(Debug)]
 pub enum SeekFrom {
@@ -266,11 +281,11 @@ impl FileLike for File {
         self.inner.write().write_at(offset, buf)
     }
 
-    fn poll(&self) -> LxResult<PollStatus> {
+    fn poll(&self, _events: PollEvents) -> LxResult<PollStatus> {
         Ok(self.inner.read().inode.poll()?)
     }
 
-    async fn async_poll(&self) -> LxResult<PollStatus> {
+    async fn async_poll(&self, _events: PollEvents) -> LxResult<PollStatus> {
         Ok(self.inner.read().inode.async_poll().await?)
     }
 

--- a/linux-object/src/net/netlink.rs
+++ b/linux-object/src/net/netlink.rs
@@ -3,6 +3,7 @@
 use super::socket_address::*;
 use crate::{
     error::{LxError, LxResult},
+    fs::FileLike,
     net::{AddressFamily, Endpoint, SockAddr, Socket, SysResult},
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
@@ -193,15 +194,11 @@ impl Socket for NetlinkSocketState {
     }
 
     /// connect
-    async fn connect(&mut self, _endpoint: Endpoint) -> SysResult {
-        unimplemented!()
-    }
-    /// wait for some event on a file descriptor
-    fn poll(&self) -> (bool, bool, bool) {
+    async fn connect(&self, _endpoint: Endpoint) -> SysResult {
         unimplemented!()
     }
 
-    fn bind(&mut self, _endpoint: Endpoint) -> SysResult {
+    fn bind(&self, _endpoint: Endpoint) -> SysResult {
         warn!("bind netlink socket");
         // if let Endpoint::Netlink(mut net_link) = endpoint {
         //     if net_link.port_id == 0 {
@@ -216,7 +213,7 @@ impl Socket for NetlinkSocketState {
         Ok(0)
     }
 
-    fn listen(&mut self) -> SysResult {
+    fn listen(&self) -> SysResult {
         unimplemented!()
     }
 
@@ -224,7 +221,7 @@ impl Socket for NetlinkSocketState {
         unimplemented!()
     }
 
-    async fn accept(&mut self) -> LxResult<(Arc<Mutex<dyn Socket>>, Endpoint)> {
+    async fn accept(&self) -> LxResult<(Arc<dyn FileLike>, Endpoint)> {
         unimplemented!()
     }
 
@@ -236,22 +233,12 @@ impl Socket for NetlinkSocketState {
         unimplemented!()
     }
 
-    fn setsockopt(&mut self, _level: usize, _opt: usize, _data: &[u8]) -> SysResult {
+    fn setsockopt(&self, _level: usize, _opt: usize, _data: &[u8]) -> SysResult {
         Ok(0)
     }
 
     fn ioctl(&self, _request: usize, _arg1: usize, _arg2: usize, _arg3: usize) -> SysResult {
         Ok(0)
-    }
-
-    fn fcntl(&self, _cmd: usize, _arg: usize) -> SysResult {
-        warn!("fnctl is unimplemented for this socket");
-        // now no fnctl impl but need to pass libctest , so just do a trick
-        match _cmd {
-            1 => Ok(1),
-            3 => Ok(0o4000),
-            _ => Ok(0),
-        }
     }
 }
 

--- a/linux-object/src/net/tcp.rs
+++ b/linux-object/src/net/tcp.rs
@@ -1,19 +1,9 @@
 // Tcpsocket
 
 // crate
-use crate::error::LxError;
-use crate::error::LxResult;
-use crate::net::get_ephemeral_port;
-use crate::net::get_sockets;
-// use crate::net::get_net_device;
-use crate::net::poll_ifaces;
-use crate::net::Endpoint;
-use crate::net::GlobalSocketHandle;
-use crate::net::IpEndpoint;
-use crate::net::Socket;
-use crate::net::SysResult;
-use crate::net::TCP_RECVBUF;
-use crate::net::TCP_SENDBUF;
+use crate::error::{LxError, LxResult};
+use crate::fs::{FileLike, OpenFlags, PollStatus};
+use crate::net::*;
 use alloc::sync::Arc;
 use lock::Mutex;
 
@@ -22,9 +12,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 
 // smoltcp
-
-use smoltcp::socket::TcpSocket;
-use smoltcp::socket::TcpSocketBuffer;
+use smoltcp::socket::{TcpSocket, TcpSocketBuffer, TcpState};
 
 // async
 use async_trait::async_trait;
@@ -33,17 +21,24 @@ use async_trait::async_trait;
 #[allow(unused_imports)]
 use zircon_object::object::*;
 
-/// missing documentation
-#[derive(Debug)]
+/// TCP socket structure
 pub struct TcpSocketState {
-    /// missing documentation
-    // base: KObjectBase,
+    /// Kernel object base
+    base: KObjectBase,
+    /// TcpSocket Inner
+    inner: Mutex<TcpInner>,
+}
+
+/// TCP socket inner
+pub struct TcpInner {
     /// missing documentation
     handle: GlobalSocketHandle,
     /// missing documentation
     local_endpoint: Option<IpEndpoint>, // save local endpoint for bind()
     /// missing documentation
     is_listening: bool,
+    /// flags on the socket
+    flags: OpenFlags,
 }
 
 impl Default for TcpSocketState {
@@ -61,10 +56,13 @@ impl TcpSocketState {
         let handle = GlobalSocketHandle(get_sockets().lock().add(socket));
 
         TcpSocketState {
-            // base: KObjectBase::new(),
-            handle,
-            local_endpoint: None,
-            is_listening: false,
+            base: KObjectBase::new(),
+            inner: Mutex::new(TcpInner {
+                handle,
+                local_endpoint: None,
+                is_listening: false,
+                flags: OpenFlags::RDWR,
+            }),
         }
     }
 }
@@ -74,153 +72,191 @@ impl Socket for TcpSocketState {
     /// read to buffer
     async fn read(&self, data: &mut [u8]) -> (SysResult, Endpoint) {
         info!("tcp read");
+        let inner = self.inner.lock();
         loop {
-            poll_ifaces();
-            let net_sockets = get_sockets();
-            let mut sockets = net_sockets.lock();
-            let mut socket = sockets.get::<TcpSocket>(self.handle.0);
-            if socket.may_recv() {
-                if let Ok(size) = socket.recv_slice(data) {
-                    if size > 0 {
-                        let endpoint = socket.remote_endpoint();
-                        // avoid deadlock
-                        drop(socket);
-                        drop(sockets);
-                        poll_ifaces();
-                        return (Ok(size), Endpoint::Ip(endpoint));
+            //poll_ifaces();
+
+            let sets = get_sockets();
+            let mut sets = sets.lock();
+            let mut socket = sets.get::<TcpSocket>(inner.handle.0);
+
+            let copied_len = socket.recv_slice(data);
+            // avoid deadlock in poll_ifaces()
+            drop(socket);
+            drop(sets);
+
+            match copied_len {
+                Ok(0) | Err(smoltcp::Error::Exhausted) => {
+                    poll_ifaces();
+                    if inner.flags.contains(OpenFlags::NON_BLOCK) {
+                        return (Err(LxError::EAGAIN), Endpoint::Ip(IpEndpoint::UNSPECIFIED));
+                    } else {
+                        // Continue reading
+                        trace!("Continue reading");
                     }
                 }
-            } else {
-                return (
-                    Err(LxError::ENOTCONN),
-                    Endpoint::Ip(IpEndpoint::UNSPECIFIED),
-                );
+                Ok(size) => {
+                    let endpoint = get_sockets()
+                        .lock()
+                        .get::<TcpSocket>(inner.handle.0)
+                        .remote_endpoint();
+                    return (Ok(size), Endpoint::Ip(endpoint));
+                }
+                Err(err) => {
+                    error!("Tcp socket read error: {:?}", err);
+                    return (
+                        Err(LxError::ENOTCONN),
+                        Endpoint::Ip(IpEndpoint::UNSPECIFIED),
+                    );
+                }
             }
         }
     }
     /// write from buffer
     fn write(&self, data: &[u8], _sendto_endpoint: Option<Endpoint>) -> SysResult {
-        info!("tcp write");
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let mut socket = sockets.get::<TcpSocket>(self.handle.0);
-        if socket.is_open() {
-            if socket.can_send() {
-                match socket.send_slice(data) {
-                    Ok(size) => {
-                        // avoid deadlock
-                        drop(socket);
-                        drop(sockets);
+        //loop {
+        let sets = get_sockets();
+        let mut sets = sets.lock();
+        let mut socket = sets.get::<TcpSocket>(self.inner.lock().handle.0);
+        let copied_len = socket.send_slice(data);
 
-                        poll_ifaces();
-                        Ok(size)
-                    }
-                    Err(_) => Err(LxError::ENOBUFS),
-                }
-            } else {
+        drop(socket);
+        drop(sets);
+        poll_ifaces();
+
+        match copied_len {
+            Ok(size) => Ok(size),
+            Err(err) => {
+                error!("Tcp socket write error: {:?}", err);
                 Err(LxError::ENOBUFS)
             }
-        } else {
-            Err(LxError::ENOTCONN)
         }
+        //}
     }
     /// connect
-    async fn connect(&mut self, endpoint: Endpoint) -> SysResult {
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let mut socket = sockets.get::<TcpSocket>(self.handle.0);
+    async fn connect(&self, endpoint: Endpoint) -> SysResult {
+        let inner = self.inner.lock();
         #[allow(warnings)]
         if let Endpoint::Ip(ip) = endpoint {
-            let local_port = get_ephemeral_port();
-            socket
-                .connect(ip, local_port)
+            get_sockets()
+                .lock()
+                .get::<TcpSocket>(inner.handle.0)
+                .connect(ip, get_ephemeral_port())
                 .map_err(|_| LxError::ENOBUFS)?;
 
-            // avoid deadlock
-            drop(socket);
-            drop(sockets);
+            let mut tc = 0;
             // wait for connection result
             loop {
+                //Submit a SYN
                 poll_ifaces();
-                let net_sockets = get_sockets();
-                let mut sockets = net_sockets.lock();
-                let socket = sockets.get::<TcpSocket>(self.handle.0);
-                use smoltcp::socket::TcpState;
-                match socket.state() {
+
+                match get_sockets()
+                    .lock()
+                    .get::<TcpSocket>(inner.handle.0)
+                    .state()
+                {
                     TcpState::SynSent => {
                         // still connecting
-                        drop(socket);
-                        drop(sockets);
-
-                        poll_ifaces();
                     }
                     TcpState::Established => {
-                        break Ok(0);
+                        return Ok(0);
                     }
                     _ => {
-                        break Err(LxError::ECONNREFUSED);
+                        warn!("connect failed ...");
+                        if tc < 10 {
+                            tc += 1;
+                        } else {
+                            return Err(LxError::ECONNREFUSED);
+                        }
                     }
                 }
             }
         } else {
-            drop(socket);
-            drop(sockets);
+            error!("connect: bad endpoint");
             Err(LxError::EINVAL)
         }
     }
     /// wait for some event on a file descriptor
-    fn poll(&self) -> (bool, bool, bool) {
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let socket = sockets.get::<TcpSocket>(self.handle.0);
+    fn poll(&self, events: PollEvents) -> (bool, bool, bool) {
+        //poll_ifaces();
+        let inner = self.inner.lock();
+        let (recv_state, send_state) = {
+            let sets = get_sockets();
+            let mut sets = sets.lock();
+            let socket = sets.get::<TcpSocket>(inner.handle.0);
+            debug!(
+                "tcp is_listening: {:?}, now tcp state: {:?}",
+                inner.is_listening,
+                socket.state()
+            );
 
-        let (mut input, mut output, mut err) = (false, false, false);
-        if self.is_listening && socket.is_active() {
+            (socket.can_recv(), socket.can_send())
+        };
+        if (events.contains(PollEvents::IN) && !recv_state)
+            || (events.contains(PollEvents::OUT) && !send_state)
+        {
+            poll_ifaces();
+        }
+
+        let (mut read, mut write, mut error) = (false, false, false);
+
+        let sets = get_sockets();
+        let mut sets = sets.lock();
+        let socket = sets.get::<TcpSocket>(inner.handle.0);
+
+        //Todo, syscall async poll needs to be executed after first Pending
+        if inner.is_listening && socket.is_active() {
             // a new connection
-            input = true;
+            read = true;
         } else if !socket.is_open() {
-            err = true;
+            error = true;
         } else {
             if socket.can_recv() {
-                input = true;
+                read = true; // POLLIN
             }
             if socket.can_send() {
-                output = true;
+                write = true; // POLLOUT
             }
         }
-        (input, output, err)
+        debug!("tcp poll: {:?}", (read, write, error));
+        (read, write, error)
     }
 
-    fn bind(&mut self, endpoint: Endpoint) -> SysResult {
+    fn bind(&self, endpoint: Endpoint) -> SysResult {
+        let mut inner = self.inner.lock();
         if let Endpoint::Ip(mut ip) = endpoint {
             if ip.port == 0 {
                 ip.port = get_ephemeral_port();
             }
-            self.local_endpoint = Some(ip);
-            self.is_listening = false;
+            inner.local_endpoint = Some(ip);
+            inner.is_listening = false;
             Ok(0)
         } else {
             Err(LxError::EINVAL)
         }
     }
 
-    fn listen(&mut self) -> SysResult {
-        if self.is_listening {
+    fn listen(&self) -> SysResult {
+        let mut inner = self.inner.lock();
+        if inner.is_listening {
             // it is ok to listen twice
+            info!("It's already listening");
             return Ok(0);
         }
-        let local_endpoint = self.local_endpoint.ok_or(LxError::EINVAL)?;
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let mut socket = sockets.get::<TcpSocket>(self.handle.0);
 
+        let local_endpoint = inner.local_endpoint.ok_or(LxError::EINVAL)?;
         info!("socket listening on {:?}", local_endpoint);
+
+        let sets = get_sockets();
+        let mut sets = sets.lock();
+        let mut socket = sets.get::<TcpSocket>(inner.handle.0);
+
         if socket.is_listening() {
             return Ok(0);
         }
         match socket.listen(local_endpoint) {
             Ok(()) => {
-                self.is_listening = true;
+                inner.is_listening = true;
                 Ok(0)
             }
             Err(_) => Err(LxError::EINVAL),
@@ -228,52 +264,64 @@ impl Socket for TcpSocketState {
     }
 
     fn shutdown(&self) -> SysResult {
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let mut socket = sockets.get::<TcpSocket>(self.handle.0);
+        let sets = get_sockets();
+        let mut sets = sets.lock();
+        let mut socket = sets.get::<TcpSocket>(self.inner.lock().handle.0);
         socket.close();
         Ok(0)
     }
 
-    async fn accept(&mut self) -> LxResult<(Arc<Mutex<dyn Socket>>, Endpoint)> {
-        let endpoint = self.local_endpoint.ok_or(LxError::EINVAL)?;
+    async fn accept(&self) -> LxResult<(Arc<dyn FileLike>, Endpoint)> {
+        let mut inner = self.inner.lock();
+        let endpoint = inner.local_endpoint.ok_or(LxError::EINVAL)?;
         loop {
-            poll_ifaces();
-            let net_sockets = get_sockets();
-            let mut sockets = net_sockets.lock();
-            let socket = sockets.get::<TcpSocket>(self.handle.0);
+            //poll_ifaces();
+            let sets = get_sockets();
+            let mut sets = sets.lock();
+            let socket = sets.get::<TcpSocket>(inner.handle.0);
             if socket.is_active() {
                 let remote_endpoint = socket.remote_endpoint();
                 drop(socket);
+                drop(sets);
+
                 let new_socket = {
                     let rx_buffer = TcpSocketBuffer::new(vec![0; TCP_RECVBUF]);
                     let tx_buffer = TcpSocketBuffer::new(vec![0; TCP_SENDBUF]);
                     let mut socket = TcpSocket::new(rx_buffer, tx_buffer);
                     socket.listen(endpoint).unwrap();
-                    let new_handle = GlobalSocketHandle(sockets.add(socket));
-                    let old_handle = ::core::mem::replace(&mut self.handle, new_handle);
-                    Arc::new(Mutex::new(TcpSocketState {
-                        // base: KObjectBase::new(),
-                        handle: old_handle,
-                        local_endpoint: self.local_endpoint,
-                        is_listening: false,
-                    }))
-                };
-                drop(sockets);
-                poll_ifaces();
-                return Ok((new_socket, Endpoint::Ip(remote_endpoint)));
-            }
 
-            drop(socket);
-            drop(sockets);
+                    let new_handle = GlobalSocketHandle(get_sockets().lock().add(socket));
+                    let old_handle = ::core::mem::replace(&mut inner.handle, new_handle);
+
+                    Arc::new(TcpSocketState {
+                        base: KObjectBase::new(),
+                        inner: Mutex::new(TcpInner {
+                            handle: old_handle,
+                            local_endpoint: inner.local_endpoint,
+                            is_listening: false,
+                            flags: OpenFlags::RDWR,
+                        }),
+                    })
+                };
+
+                return Ok((
+                    new_socket as Arc<dyn FileLike>,
+                    Endpoint::Ip(remote_endpoint),
+                ));
+            } else {
+                drop(socket);
+                drop(sets);
+                poll_ifaces();
+            }
         }
     }
 
     fn endpoint(&self) -> Option<Endpoint> {
-        self.local_endpoint.map(Endpoint::Ip).or_else(|| {
-            let net_sockets = get_sockets();
-            let mut sockets = net_sockets.lock();
-            let socket = sockets.get::<TcpSocket>(self.handle.0);
+        let inner = self.inner.lock();
+        inner.local_endpoint.map(Endpoint::Ip).or_else(|| {
+            let sets = get_sockets();
+            let mut sets = sets.lock();
+            let socket = sets.get::<TcpSocket>(inner.handle.0);
             let endpoint = socket.local_endpoint();
             if endpoint.port != 0 {
                 Some(Endpoint::Ip(endpoint))
@@ -284,9 +332,9 @@ impl Socket for TcpSocketState {
     }
 
     fn remote_endpoint(&self) -> Option<Endpoint> {
-        let net_sockets = get_sockets();
-        let mut sockets = net_sockets.lock();
-        let socket = sockets.get::<TcpSocket>(self.handle.0);
+        let sets = get_sockets();
+        let mut sets = sets.lock();
+        let socket = sets.get::<TcpSocket>(self.inner.lock().handle.0);
         if socket.is_open() {
             Some(Endpoint::Ip(socket.remote_endpoint()))
         } else {
@@ -294,21 +342,81 @@ impl Socket for TcpSocketState {
         }
     }
 
-    fn setsockopt(&mut self, _level: usize, _opt: usize, _data: &[u8]) -> SysResult {
-        Ok(0)
+    fn get_buffer_capacity(&self) -> Option<(usize, usize)> {
+        let sockets = get_sockets();
+        let mut set = sockets.lock();
+        let socket = set.get::<TcpSocket>(self.inner.lock().handle.0);
+        let (recv_ca, send_ca) = (socket.recv_capacity(), socket.send_capacity());
+        Some((recv_ca, send_ca))
     }
 
-    fn ioctl(&self, _request: usize, _arg1: usize, _arg2: usize, _arg3: usize) -> SysResult {
-        Ok(0)
+    fn socket_type(&self) -> Option<SocketType> {
+        Some(SocketType::SOCK_STREAM)
+    }
+}
+
+impl_kobject!(TcpSocketState);
+
+#[async_trait]
+impl FileLike for TcpSocketState {
+    fn flags(&self) -> OpenFlags {
+        self.inner.lock().flags
     }
 
-    fn fcntl(&self, _cmd: usize, _arg: usize) -> SysResult {
-        warn!("fnctl is unimplemented for this socket");
-        // now no fnctl impl but need to pass libctest , so just do a trick
-        match _cmd {
-            1 => Ok(1),
-            3 => Ok(0o4000),
-            _ => Ok(0),
-        }
+    fn set_flags(&self, f: OpenFlags) -> LxResult {
+        let flags = &mut self.inner.lock().flags;
+
+        // See fcntl, only O_APPEND, O_ASYNC, O_DIRECT, O_NOATIME, O_NONBLOCK
+        flags.set(OpenFlags::APPEND, f.contains(OpenFlags::APPEND));
+        flags.set(OpenFlags::NON_BLOCK, f.contains(OpenFlags::NON_BLOCK));
+        flags.set(OpenFlags::CLOEXEC, f.contains(OpenFlags::CLOEXEC));
+        Ok(())
+    }
+
+    fn dup(&self) -> Arc<dyn FileLike> {
+        unimplemented!()
+        /*
+        let sockets = get_sockets();
+        let mut set = sockets.lock();
+        let socket = set.get::<TcpSocket>(self.handle.0);
+        let new_handle = GlobalSocketHandle(set.add(*socket));
+        Arc::new(Self {
+            base: KObjectBase::new(),
+            handle: new_handle,
+            local_endpoint: self.local_endpoint,
+            is_listening: self.is_listening,
+            flags: RwLock::new(*self.flags.read()),
+        })
+        */
+    }
+
+    async fn read(&self, buf: &mut [u8]) -> LxResult<usize> {
+        Socket::read(self, buf).await.0
+    }
+
+    async fn read_at(&self, _offset: u64, _buf: &mut [u8]) -> LxResult<usize> {
+        unimplemented!()
+    }
+
+    fn write(&self, buf: &[u8]) -> LxResult<usize> {
+        Socket::write(self, buf, None)
+    }
+
+    fn poll(&self, events: PollEvents) -> LxResult<PollStatus> {
+        let (read, write, error) = Socket::poll(self, events);
+        Ok(PollStatus { read, write, error })
+    }
+
+    async fn async_poll(&self, events: PollEvents) -> LxResult<PollStatus> {
+        let (read, write, error) = Socket::poll(self, events);
+        Ok(PollStatus { read, write, error })
+    }
+
+    fn ioctl(&self, request: usize, arg1: usize, arg2: usize, arg3: usize) -> LxResult<usize> {
+        Socket::ioctl(self, request, arg1, arg2, arg3)
+    }
+
+    fn as_socket(&self) -> LxResult<&dyn Socket> {
+        Ok(self)
     }
 }

--- a/linux-syscall/src/file/file.rs
+++ b/linux-syscall/src/file/file.rs
@@ -21,23 +21,11 @@ impl Syscall<'_> {
     pub async fn sys_read(&self, fd: FileDesc, mut base: UserOutPtr<u8>, len: usize) -> SysResult {
         info!("read: fd={:?}, base={:?}, len={:#x}", fd, base, len);
         let proc = self.linux_process();
-
-        // TODO wait a new struct to refactor
-        if usize::from(fd) >= SOCKET_FD {
-            let x = usize::from(fd);
-            let socket = proc.get_socket(x)?;
-            let mut buf = vec![0u8; len];
-            let (len, _) = socket.lock().read(&mut buf).await;
-            let len = len.unwrap_or(0);
-            base.write_array(&buf[..len])?;
-            Ok(len)
-        } else {
-            let file_like = proc.get_file_like(fd)?;
-            let mut buf = vec![0u8; len];
-            let len = file_like.read(&mut buf).await?;
-            base.write_array(&buf[..len])?;
-            Ok(len)
-        }
+        let file_like = proc.get_file_like(fd)?;
+        let mut buf = vec![0u8; len];
+        let len = file_like.read(&mut buf).await?;
+        base.write_array(&buf[..len])?;
+        Ok(len)
     }
 
     /// Writes to a specified file using a file descriptor. Before using this call,
@@ -104,23 +92,11 @@ impl Syscall<'_> {
         info!("readv: fd={:?}, iov={:?}, count={}", fd, iov_ptr, iov_count);
         let mut iovs = iov_ptr.read_iovecs(iov_count)?;
         let proc = self.linux_process();
-
-        // TODO wait a new struct to refactor
-        if usize::from(fd) >= SOCKET_FD {
-            let x = usize::from(fd);
-            let socket = proc.get_socket(x)?;
-            let mut buf = vec![0u8; iovs.total_len()];
-            let (len, _) = socket.lock().read(&mut buf).await;
-            let len = len.unwrap();
-            iovs.write_from_buf(&buf)?;
-            Ok(len)
-        } else {
-            let file_like = proc.get_file_like(fd)?;
-            let mut buf = vec![0u8; iovs.total_len()];
-            let len = file_like.read(&mut buf).await?;
-            iovs.write_from_buf(&buf)?;
-            Ok(len)
-        }
+        let file_like = proc.get_file_like(fd)?;
+        let mut buf = vec![0u8; iovs.total_len()];
+        let len = file_like.read(&mut buf).await?;
+        iovs.write_from_buf(&buf)?;
+        Ok(len)
     }
 
     /// works just like write except that multiple buffers are written out.
@@ -139,18 +115,9 @@ impl Syscall<'_> {
         let iovs = iov_ptr.read_iovecs(iov_count)?;
         let buf = iovs.read_to_vec()?;
         let proc = self.linux_process();
-
-        // TODO wait a new struct to refactor
-        if usize::from(fd) >= SOCKET_FD {
-            let x = usize::from(fd);
-            let socket = proc.get_socket(x)?;
-            let len = socket.lock().write(&buf, None)?;
-            Ok(len)
-        } else {
-            let file_like = proc.get_file_like(fd)?;
-            let len = file_like.write(&buf)?;
-            Ok(len)
-        }
+        let file_like = proc.get_file_like(fd)?;
+        let len = file_like.write(&buf)?;
+        Ok(len)
     }
 
     /// repositions the offset of the open file associated with the file descriptor fd
@@ -319,71 +286,52 @@ impl Syscall<'_> {
             fd, request, arg1, arg2, arg3
         );
         let proc = self.linux_process();
-
-        // TODO wait a new struct to refactor
-        if usize::from(fd) >= SOCKET_FD {
-            let f = usize::from(fd);
-            let socket = proc.get_socket(f)?;
-            let x = socket.lock();
-            x.ioctl(request, arg1, arg2, arg3)
-        } else {
-            let file_like = proc.get_file_like(fd)?;
-            file_like.ioctl(request, arg1, arg2, arg3)
-        }
+        let file_like = proc.get_file_like(fd)?;
+        file_like.ioctl(request, arg1, arg2, arg3)
     }
 
     /// Manipulate a file descriptor.
     /// - cmd – cmd flag
     /// - arg – additional parameters based on cmd
     pub fn sys_fcntl(&self, fd: FileDesc, cmd: usize, arg: usize) -> SysResult {
-        info!("fcntl: fd={:?}, cmd={:x}, arg={}", fd, cmd, arg);
+        info!("fcntl: fd={:?}, cmd={}, arg={}", fd, cmd, arg);
         let proc = self.linux_process();
-
-        // TODO wait a new struct to refactor
-        if usize::from(fd) >= SOCKET_FD {
-            let f = usize::from(fd);
-            let socket = proc.get_socket(f)?;
-            let x = socket.lock();
-            x.fcntl(cmd, arg)
-        } else {
-            let file_like = proc.get_file_like(fd)?;
-
-            if let Ok(cmd) = FcntlCmd::try_from(cmd) {
-                match cmd {
-                    FcntlCmd::GETFD => Ok(file_like.flags().close_on_exec() as usize),
-                    FcntlCmd::SETFD => {
-                        let mut flags = file_like.flags();
-                        if (arg & 1) != 0 {
-                            flags |= OpenFlags::CLOEXEC;
-                        } else {
-                            flags -= OpenFlags::CLOEXEC;
-                        }
-                        file_like.set_flags(flags)?;
-                        Ok(0)
+        let file_like = proc.get_file_like(fd)?;
+        if let Ok(cmd) = FcntlCmd::try_from(cmd) {
+            match cmd {
+                FcntlCmd::GETFD => Ok(file_like.flags().close_on_exec() as usize),
+                FcntlCmd::SETFD => {
+                    let mut flags = file_like.flags();
+                    if (arg & 1) != 0 {
+                        flags |= OpenFlags::CLOEXEC;
+                    } else {
+                        flags -= OpenFlags::CLOEXEC;
                     }
-                    FcntlCmd::GETFL => Ok(file_like.flags().bits()),
-                    FcntlCmd::SETFL => {
-                        file_like.set_flags(OpenFlags::from_bits_truncate(arg))?;
-                        Ok(0)
-                    }
-                    FcntlCmd::DUPFD | FcntlCmd::DUPFD_CLOEXEC => {
-                        let new_fd = proc.get_free_fd_from(arg);
-                        self.sys_dup2(fd, new_fd)?;
-                        let dup = proc.get_file_like(new_fd)?;
-                        let mut flags = dup.flags();
-                        if cmd == FcntlCmd::DUPFD_CLOEXEC {
-                            flags |= OpenFlags::CLOEXEC;
-                        } else {
-                            flags -= OpenFlags::CLOEXEC;
-                        }
-                        dup.set_flags(flags)?;
-                        Ok(new_fd.into())
-                    }
-                    _ => Err(LxError::EINVAL),
+                    file_like.set_flags(flags)?;
+                    Ok(0)
                 }
-            } else {
-                Err(LxError::EINVAL)
+                FcntlCmd::GETFL => Ok(file_like.flags().bits()),
+                FcntlCmd::SETFL => {
+                    file_like.set_flags(OpenFlags::from_bits_truncate(arg))?;
+                    Ok(0)
+                }
+                FcntlCmd::DUPFD | FcntlCmd::DUPFD_CLOEXEC => {
+                    let new_fd = proc.get_free_fd_from(arg);
+                    self.sys_dup2(fd, new_fd)?;
+                    let dup = proc.get_file_like(new_fd)?;
+                    let mut flags = dup.flags();
+                    if cmd == FcntlCmd::DUPFD_CLOEXEC {
+                        flags |= OpenFlags::CLOEXEC;
+                    } else {
+                        flags -= OpenFlags::CLOEXEC;
+                    }
+                    dup.set_flags(flags)?;
+                    Ok(new_fd.into())
+                }
+                _ => Err(LxError::EINVAL),
             }
+        } else {
+            Err(LxError::EINVAL)
         }
     }
 
@@ -585,6 +533,3 @@ numeric_enum_macro::numeric_enum! {
         DUPFD_CLOEXEC = F_LINUX_SPECIFIC_BASE + 6,
     }
 }
-
-// Temp , TODO warp a struct impl into/from with FileDesc and SocketHandle
-const SOCKET_FD: usize = 10000;

--- a/linux-syscall/src/lib.rs
+++ b/linux-syscall/src/lib.rs
@@ -144,7 +144,11 @@ impl Syscall<'_> {
             Sys::MMAP => self.sys_mmap(a0, a1, a2, a3, a4.into(), a5 as _).await,
             Sys::MPROTECT => self.sys_mprotect(a0, a1, a2),
             Sys::MUNMAP => self.sys_munmap(a0, a1),
-            Sys::MADVISE => self.unimplemented("madvise", Ok(0)),
+            Sys::MADVISE => {
+                info!("madvise unimplemented");
+                Ok(0)
+            }
+            Sys::MREMAP => self.unimplemented("mremap", Err(LxError::ENOMEM)),
 
             // signal
             Sys::RT_SIGACTION => self.sys_rt_sigaction(a0, a1.into(), a2.into(), a3),

--- a/zCore/Makefile
+++ b/zCore/Makefile
@@ -182,6 +182,7 @@ endif
 qemu_opts += \
 	-netdev user,id=net1,hostfwd=tcp::8000-:80,hostfwd=tcp::2222-:2222,hostfwd=udp::6969-:6969 \
 	-device e1000e,netdev=net1
+	# -netdev tap,id=net1,script=ifup.sh,downscript=ifdown.sh
 
 ifeq ($(DISK), on)
   ifeq ($(ARCH), x86_64)

--- a/zCore/src/platform/riscv/entry.rs
+++ b/zCore/src/platform/riscv/entry.rs
@@ -3,7 +3,7 @@ use super::{
     consts::{kernel_mem_info, MAX_HART_NUM, STACK_PAGES_PER_HART},
 };
 use core::arch::asm;
-use dtb_walker::{Dtb, DtbObj, HeaderError::*, Property, Str, WalkOperation::*};
+use dtb_walker::{Dtb, DtbObj, Property, Str, WalkOperation::*};
 use kernel_hal::KernelConfig;
 
 /// 内核入口。
@@ -57,12 +57,7 @@ extern "C" fn primary_rust_main(hartid: usize, device_tree_paddr: usize) -> ! {
     };
     // 检查设备树
     // 副核启动完成前跳板页一直存在，所以可以使用物理地址直接访问设备树
-    let dtb = unsafe {
-        Dtb::from_raw_parts_filtered(device_tree_paddr as _, |e| {
-            matches!(e, Misaligned(4) | LastCompVersion(16))
-        })
-    }
-    .unwrap();
+    let dtb = unsafe { Dtb::from_raw_parts_unchecked(device_tree_paddr as _) };
     let mem_info = kernel_mem_info();
     // 打印启动信息
     println!(


### PR DESCRIPTION
Test camera module with UDP rtsp;
Implemented FileLike for TCP and UDP;
Binding FileLike trait to Socket trait;
Modified the mut lock of Socket object;
Clean up the socket code in linux process file;
Adjust tcp/udp buffer and disable CRC check and keep FCS in rtl net driver;
Fix getsocket syscall and add get_buffer_capacity interface;
Fix socket deadlock problem in tcp/udp;
Modified tcp/udp read write functions;
Add poll() parameter;
Add socket testcases: tcp/udp nonblock/block poll and modified current testcases;