### PR TITLE
在 risc-v64 和 aarch64 上实现动态内核堆

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "customizable-buddy"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6c584413bb642e0f8c33faa63d7bd285335eb01b4db80be4119926ddcb96be"
+
+[[package]]
 name = "cxx"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +2565,7 @@ dependencies = [
  "buddy_system_allocator",
  "cfg-if 1.0.0",
  "chrono",
+ "customizable-buddy",
  "dtb-walker",
  "executor",
  "kernel-hal",

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -64,25 +64,22 @@ log = "0.4"
 cfg-if = "1.0"
 spin = "0.9.4"
 customizable-buddy = "0.0.3"
-bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
 kernel-hal = { path = "../kernel-hal", default-features = false }
 zcore-loader = { path = "../loader", default-features = false }
 zircon-object = { path = "../zircon-object" }
+lock = { git = "https://github.com/DeathWish5/kernel-sync", rev = "8486b8" }
+executor = { git = "https://github.com/DeathWish5/PreemptiveScheduler", rev = "e8cd353" }
+
 linux-object = { path = "../linux-object", optional = true }
 rcore-fs = { git = "https://github.com/rcore-os/rcore-fs", rev = "1a3246b", optional = true }
 rcore-fs-sfs = { git = "https://github.com/rcore-os/rcore-fs", rev = "1a3246b", optional = true }
-lock = { git = "https://github.com/DeathWish5/kernel-sync", rev = "8486b8" }
-executor = { git = "https://github.com/DeathWish5/PreemptiveScheduler", rev = "e8cd353" }
 
 # LibOS mode
 [target.'cfg(not(target_os = "none"))'.dependencies]
 async-std = { version = "1.10", optional = true }
 chrono = { version = "0.4", optional = true }
+bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
 rcore-fs-hostfs = { git = "https://github.com/rcore-os/rcore-fs", rev = "1a3246b", optional = true }
-
-# Bare-metal mode
-[target.'cfg(target_os = "none")'.dependencies]
-buddy_system_allocator = "0.8"
 
 # RISC-V
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
@@ -92,11 +89,13 @@ dtb-walker = "=0.2.0-alpha.3"
 page-table = "0.0.6"
 sbi-rt = { version = "0.0.2", features = ["legacy"] }
 
-# Bare-metal mode on x86_64
-[target.'cfg(all(target_os = "none", target_arch = "x86_64"))'.dependencies]
-rboot = { git = "https://github.com/rcore-os/rboot.git", rev = "ad21575", default-features = false }
-# rvm = { git = "https://github.com/rcore-os/RVM", rev = "e91d625", optional = true }
-
 # Bare-metal mode on aarch64
 [target.'cfg(all(target_os = "none", target_arch = "aarch64"))'.dependencies]
 rayboot = { git = "https://github.com/Luchangcheng2333/rayboot", rev = "b19c6c3" }
+
+# Bare-metal mode on x86_64
+[target.'cfg(all(target_os = "none", target_arch = "x86_64"))'.dependencies]
+bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
+buddy_system_allocator = "0.8"
+rboot = { git = "https://github.com/rcore-os/rboot.git", rev = "ad21575", default-features = false }
+# rvm = { git = "https://github.com/rcore-os/RVM", rev = "e91d625", optional = true }

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -62,7 +62,8 @@ mock-disk = ["linux-object/mock-disk"]
 [dependencies]
 log = "0.4"
 cfg-if = "1.0"
-spin = "0.9.3"
+spin = "0.9.4"
+customizable-buddy = "0.0.3"
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
 kernel-hal = { path = "../kernel-hal", default-features = false }
 zcore-loader = { path = "../loader", default-features = false }

--- a/zCore/src/handler.rs
+++ b/zCore/src/handler.rs
@@ -7,11 +7,11 @@ pub struct ZcoreKernelHandler;
 
 impl KernelHandler for ZcoreKernelHandler {
     fn frame_alloc(&self) -> Option<usize> {
-        memory::frame_alloc()
+        memory::frame_alloc(1, 0)
     }
 
     fn frame_alloc_contiguous(&self, frame_count: usize, align_log2: usize) -> Option<usize> {
-        memory::frame_alloc_contiguous(frame_count, align_log2)
+        memory::frame_alloc(frame_count, align_log2)
     }
 
     fn frame_dealloc(&self, paddr: usize) {

--- a/zCore/src/memory.rs
+++ b/zCore/src/memory.rs
@@ -1,4 +1,4 @@
-//! Define physical frame allocation and dynamic memory allocation.
+//! Define dynamic memory allocation.
 
 use crate::platform::phys_to_virt_offset;
 use alloc::alloc::handle_alloc_error;
@@ -12,11 +12,13 @@ use customizable_buddy::{BuddyAllocator, LinkedListBuddy, UsizeBuddy};
 use kernel_hal::PhysAddr;
 use lock::Mutex;
 
-/// 标准分配器类型。
-type MutAllocator<const N: usize> = BuddyAllocator<N, UsizeBuddy, LinkedListBuddy>;
-
 /// 堆分配器。
-static HEAP: Mutex<MutAllocator<27>> = Mutex::new(MutAllocator::new()); // 27 + 6 + 3  = 36 -> 16 GiB
+///
+/// 27 + 6 + 3 = 36 -> 64 GiB
+struct LockedHeap(Mutex<BuddyAllocator<27, UsizeBuddy, LinkedListBuddy>>);
+
+#[global_allocator]
+static HEAP: LockedHeap = LockedHeap(Mutex::new(BuddyAllocator::new()));
 
 /// 单页地址位数。
 const PAGE_BITS: usize = 12;
@@ -24,8 +26,53 @@ const PAGE_BITS: usize = 12;
 /// 为启动准备的初始内存。
 static mut MEMORY: [u8; 4 * 4096] = [0u8; 4 * 4096];
 
+unsafe impl GlobalAlloc for LockedHeap {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if let Ok((ptr, _)) = self.0.lock().allocate_layout(layout) {
+            ptr.as_ptr()
+        } else {
+            handle_alloc_error(layout)
+        }
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.0
+            .lock()
+            .deallocate_layout(NonNull::new(ptr).unwrap(), layout)
+    }
+}
+
+/// 初始化分配器，并将一个小的内存块注册到分配器中，用于启动需要的动态内存。
+pub fn init() {
+    unsafe {
+        log::info!("MEMORY = {:#?}", MEMORY.as_ptr_range());
+        let mut heap = HEAP.0.lock();
+        let ptr = NonNull::new(MEMORY.as_mut_ptr()).unwrap();
+        heap.init(core::mem::size_of::<usize>().trailing_zeros() as _, ptr);
+        heap.transfer(ptr, MEMORY.len());
+    }
+}
+
+/// 将一些内存区域注册到分配器。
+pub fn insert_regions(regions: &[Range<PhysAddr>]) {
+    let mut heap = HEAP.0.lock();
+    let offset = phys_to_virt_offset();
+    regions
+        .iter()
+        .filter(|region| !region.is_empty())
+        .for_each(|region| unsafe {
+            heap.transfer(
+                NonNull::new_unchecked((region.start + offset) as *mut u8),
+                region.len(),
+            );
+        });
+}
+
 pub fn frame_alloc(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
     let (ptr, size) = HEAP
+        .0
         .lock()
         .allocate::<u8>(align_log2 << PAGE_BITS, unsafe {
             NonZeroUsize::new_unchecked(frame_count << PAGE_BITS)
@@ -36,52 +83,8 @@ pub fn frame_alloc(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
 }
 
 pub fn frame_dealloc(target: PhysAddr) {
-    HEAP.lock().deallocate(
+    HEAP.0.lock().deallocate(
         unsafe { NonNull::new_unchecked((target + phys_to_virt_offset()) as *mut u8) },
         1 << PAGE_BITS,
     );
-}
-
-pub fn init() {
-    unsafe {
-        log::info!("MEMORY = {:#?}", MEMORY.as_ptr_range());
-        let mut heap = HEAP.lock();
-        let ptr = NonNull::new(MEMORY.as_mut_ptr()).unwrap();
-        heap.init(core::mem::size_of::<usize>().trailing_zeros() as _, ptr);
-        heap.transfer(ptr, MEMORY.len());
-    }
-}
-
-pub fn insert_regions(regions: &[Range<PhysAddr>]) {
-    let offset = phys_to_virt_offset();
-    regions
-        .iter()
-        .filter(|region| !region.is_empty())
-        .for_each(|region| unsafe {
-            HEAP.lock().transfer(
-                NonNull::new_unchecked((region.start + offset) as *mut u8),
-                region.len(),
-            );
-        });
-}
-
-struct Global;
-
-#[global_allocator]
-static GLOBAL: Global = Global;
-
-unsafe impl GlobalAlloc for Global {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if let Ok((ptr, _)) = HEAP.lock().allocate_layout::<u8>(layout) {
-            ptr.as_ptr()
-        } else {
-            handle_alloc_error(layout)
-        }
-    }
-
-    #[inline]
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        HEAP.lock()
-            .deallocate_layout(NonNull::new(ptr).unwrap(), layout)
-    }
 }

--- a/zCore/src/memory.rs
+++ b/zCore/src/memory.rs
@@ -1,168 +1,98 @@
 //! Define physical frame allocation and dynamic memory allocation.
 
-use super::platform::consts;
-use bitmap_allocator::BitAlloc;
-use core::ops::Range;
+use crate::platform::phys_to_virt_offset;
+use alloc::alloc::handle_alloc_error;
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    num::NonZeroUsize,
+    ops::Range,
+    ptr::NonNull,
+};
+use customizable_buddy::{BuddyAllocator, LinkedListBuddy, UsizeBuddy};
 use kernel_hal::PhysAddr;
 use lock::Mutex;
 
-type FrameAlloc = bitmap_allocator::BitAlloc16M; // max 64G
+/// 标准分配器类型。
+type MutAllocator<const N: usize> = BuddyAllocator<N, UsizeBuddy, LinkedListBuddy>;
 
+/// 堆分配器。
+static HEAP: Mutex<MutAllocator<27>> = Mutex::new(MutAllocator::new()); // 27 + 6 + 3  = 36 -> 16 GiB
+
+/// 单页地址位数。
 const PAGE_BITS: usize = 12;
 
-/// Global physical frame allocator
-static FRAME_ALLOCATOR: Mutex<FrameAlloc> = Mutex::new(FrameAlloc::DEFAULT);
+/// 为启动准备的初始页数。
+const BOOT_PAGES: usize = 512;
 
-#[inline]
-fn phys_addr_to_frame_idx(addr: PhysAddr) -> usize {
-    (addr - consts::phys_memory_base()) >> PAGE_BITS
-}
-
-#[inline]
-fn frame_idx_to_phys_addr(idx: usize) -> PhysAddr {
-    (idx << PAGE_BITS) + consts::phys_memory_base()
-}
-
-pub fn init_frame_allocator(regions: &[Range<PhysAddr>]) {
-    debug!("init_frame_allocator regions: {regions:x?}");
-    let mut ba = FRAME_ALLOCATOR.lock();
-    for region in regions {
-        let frame_start = phys_addr_to_frame_idx(region.start);
-        let frame_end = phys_addr_to_frame_idx(region.end - 1) + 1;
-        if frame_start < frame_end {
-            ba.insert(frame_start..frame_end);
-            info!(
-                "Frame allocator: add range {:#x?}",
-                frame_idx_to_phys_addr(frame_start)..frame_idx_to_phys_addr(frame_end),
-            );
-        }
-    }
-    info!("Frame allocator init end.");
-}
-
-pub fn frame_alloc() -> Option<PhysAddr> {
-    let ret = FRAME_ALLOCATOR.lock().alloc().map(frame_idx_to_phys_addr);
-    trace!("frame_alloc(): {ret:x?}");
-    ret
-}
-
-pub fn frame_alloc_contiguous(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
-    let ret = FRAME_ALLOCATOR
+pub fn frame_alloc(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
+    let (ptr, size) = HEAP
         .lock()
-        .alloc_contiguous(frame_count, align_log2)
-        .map(frame_idx_to_phys_addr);
-    trace!(
-        "frame_alloc_contiguous(): {ret:x?} ~ {end_ret:x?}, align_log2={align_log2}",
-        end_ret = ret.map(|x| x + frame_count),
-    );
-    ret
+        .allocate::<u8>(align_log2 << PAGE_BITS, unsafe {
+            NonZeroUsize::new_unchecked(frame_count << PAGE_BITS)
+        })
+        .ok()?;
+    assert_eq!(size, frame_count << PAGE_BITS);
+    Some(ptr.as_ptr() as PhysAddr - phys_to_virt_offset())
 }
 
 pub fn frame_dealloc(target: PhysAddr) {
-    trace!("frame_dealloc(): {target:x}");
-    FRAME_ALLOCATOR
-        .lock()
-        .dealloc(phys_addr_to_frame_idx(target))
+    HEAP.lock().deallocate(
+        unsafe { NonNull::new_unchecked((target + phys_to_virt_offset()) as *mut u8) },
+        1 << PAGE_BITS,
+    );
 }
 
-cfg_if! {
-    if #[cfg(not(feature = "libos"))] {
-        use buddy_system_allocator::Heap;
-        use core::{
-            alloc::{GlobalAlloc, Layout},
-            ops::Deref,
-            ptr::NonNull,
-        };
-        const ORDER: usize = 32;
+pub fn init() {
+    /// 4 KiB 页类型。
+    #[repr(C, align(4096))]
+    pub struct Memory<const N: usize>([[u8; 4096]; N]);
 
-        /// Global heap allocator
-        ///
-        /// Available after `memory::init_heap()`.
-        #[global_allocator]
-        static HEAP_ALLOCATOR: LockedHeap<ORDER> = LockedHeap::<ORDER>::new();
+    /// 托管空间 2 MiB
+    static mut MEMORY: Memory<BOOT_PAGES> = Memory([[0u8; 4096]; BOOT_PAGES]);
+    unsafe {
+        let ptr = NonNull::new(MEMORY.0.as_mut_ptr()).unwrap();
+        log::info!(
+            "MEMORY = {:#x}..{:#x}",
+            ptr.as_ptr() as usize,
+            ptr.as_ptr() as usize + (BOOT_PAGES << PAGE_BITS)
+        );
 
-        /// Initialize the global heap allocator.
-        pub fn init_heap() {
-            const MACHINE_ALIGN: usize = core::mem::size_of::<usize>();
-            const HEAP_BLOCK: usize = consts::KERNEL_HEAP_SIZE / MACHINE_ALIGN;
-            static mut HEAP: [usize; HEAP_BLOCK] = [0; HEAP_BLOCK];
-            let heap_start = unsafe { HEAP.as_ptr() as usize };
-            unsafe {
-                HEAP_ALLOCATOR
-                    .lock()
-                    .init(heap_start, HEAP_BLOCK * MACHINE_ALIGN);
-            }
-            info!(
-                "Heap init end: {:#x?}",
-                heap_start..heap_start + consts::KERNEL_HEAP_SIZE
+        let mut heap = HEAP.lock();
+        heap.init(core::mem::size_of::<usize>().trailing_zeros() as _, ptr);
+        heap.transfer(ptr, BOOT_PAGES << PAGE_BITS);
+    }
+}
+
+pub fn insert_regions(regions: &[Range<PhysAddr>]) {
+    let offset = phys_to_virt_offset();
+    regions
+        .iter()
+        .filter(|region| !region.is_empty())
+        .for_each(|region| unsafe {
+            HEAP.lock().transfer(
+                NonNull::new_unchecked((region.start + offset) as *mut u8),
+                region.len(),
             );
-        }
-
-        pub struct LockedHeap<const ORDER: usize>(Mutex<Heap<ORDER>>);
-
-        impl<const ORDER: usize> LockedHeap<ORDER> {
-            /// Creates an empty heap
-            pub const fn new() -> Self {
-                LockedHeap(Mutex::new(Heap::<ORDER>::new()))
-            }
-        }
-
-        impl<const ORDER: usize> Deref for LockedHeap<ORDER> {
-            type Target = Mutex<Heap<ORDER>>;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeap<ORDER> {
-            unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-                self.0
-                    .lock()
-                    .alloc(layout)
-                    .ok()
-                    .map_or(core::ptr::null_mut::<u8>(), |allocation| allocation.as_ptr())
-            }
-
-            unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-                self.0.lock().dealloc(NonNull::new_unchecked(ptr), layout)
-            }
-        }
-    } else {
-        pub fn init_heap() {}
-    }
+        });
 }
 
-#[cfg(feature = "hypervisor")]
-mod rvm_extern_fn {
-    use super::*;
+struct Global;
 
-    #[rvm::extern_fn(alloc_frame)]
-    fn rvm_alloc_frame() -> Option<usize> {
-        hal_frame_alloc()
+#[global_allocator]
+static GLOBAL: Global = Global;
+
+unsafe impl GlobalAlloc for Global {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if let Ok((ptr, _)) = HEAP.lock().allocate_layout::<u8>(layout) {
+            ptr.as_ptr()
+        } else {
+            handle_alloc_error(layout)
+        }
     }
 
-    #[rvm::extern_fn(dealloc_frame)]
-    fn rvm_dealloc_frame(paddr: usize) {
-        hal_frame_dealloc(&paddr)
-    }
-
-    #[rvm::extern_fn(phys_to_virt)]
-    fn rvm_phys_to_virt(paddr: usize) -> usize {
-        // 示意，这个常量已经没了
-        // pub const PHYSICAL_MEMORY_OFFSET: usize = KERNEL_OFFSET - PHYS_MEMORY_BASE;
-        paddr + PHYSICAL_MEMORY_OFFSET
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[rvm::extern_fn(is_host_timer_interrupt)]
-    fn rvm_is_host_timer_interrupt(vector: u8) -> bool {
-        vector == 32 // IRQ0 + Timer in kernel-hal-bare/src/arch/x86_64/interrupt.rs
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[rvm::extern_fn(is_host_serial_interrupt)]
-    fn rvm_is_host_serial_interrupt(vector: u8) -> bool {
-        vector == 36 // IRQ0 + COM1 in kernel-hal-bare/src/arch/x86_64/interrupt.rs
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        HEAP.lock()
+            .deallocate_layout(NonNull::new(ptr).unwrap(), layout)
     }
 }

--- a/zCore/src/memory.rs
+++ b/zCore/src/memory.rs
@@ -24,7 +24,9 @@ static HEAP: LockedHeap = LockedHeap(Mutex::new(BuddyAllocator::new()));
 const PAGE_BITS: usize = 12;
 
 /// 为启动准备的初始内存。
-static mut MEMORY: [u8; 4 * 4096] = [0u8; 4 * 4096];
+///
+/// 经测试 16 KiB 单核够用，多核不够，故此处给了 32 KiB。
+static mut MEMORY: [u8; 8 * 4096] = [0u8; 8 * 4096];
 
 unsafe impl GlobalAlloc for LockedHeap {
     #[inline]

--- a/zCore/src/memory_x86_64.rs
+++ b/zCore/src/memory_x86_64.rs
@@ -1,0 +1,163 @@
+﻿//! Define physical frame allocation and dynamic memory allocation.
+
+use bitmap_allocator::BitAlloc;
+use core::ops::Range;
+use kernel_hal::PhysAddr;
+use lock::Mutex;
+
+type FrameAlloc = bitmap_allocator::BitAlloc16M; // max 64G
+
+const PAGE_BITS: usize = 12;
+
+/// Global physical frame allocator
+static FRAME_ALLOCATOR: Mutex<FrameAlloc> = Mutex::new(FrameAlloc::DEFAULT);
+
+#[inline]
+fn phys_addr_to_frame_idx(addr: PhysAddr) -> usize {
+    addr >> PAGE_BITS
+}
+
+#[inline]
+fn frame_idx_to_phys_addr(idx: usize) -> PhysAddr {
+    idx << PAGE_BITS
+}
+
+pub fn insert_regions(regions: &[Range<PhysAddr>]) {
+    debug!("init_frame_allocator regions: {regions:x?}");
+    let mut ba = FRAME_ALLOCATOR.lock();
+    for region in regions {
+        let frame_start = phys_addr_to_frame_idx(region.start);
+        let frame_end = phys_addr_to_frame_idx(region.end - 1) + 1;
+        if frame_start < frame_end {
+            ba.insert(frame_start..frame_end);
+            info!(
+                "Frame allocator: add range {:#x?}",
+                frame_idx_to_phys_addr(frame_start)..frame_idx_to_phys_addr(frame_end),
+            );
+        }
+    }
+    info!("Frame allocator init end.");
+}
+
+pub fn frame_alloc(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
+    let ret = FRAME_ALLOCATOR
+        .lock()
+        .alloc_contiguous(frame_count, align_log2)
+        .map(frame_idx_to_phys_addr);
+    trace!(
+        "frame_alloc_contiguous(): {ret:x?} ~ {end_ret:x?}, align_log2={align_log2}",
+        end_ret = ret.map(|x| x + frame_count),
+    );
+    ret
+}
+
+pub fn frame_dealloc(target: PhysAddr) {
+    trace!("frame_dealloc(): {target:x}");
+    FRAME_ALLOCATOR
+        .lock()
+        .dealloc(phys_addr_to_frame_idx(target))
+}
+
+cfg_if! {
+    if #[cfg(not(feature = "libos"))] {
+        use buddy_system_allocator::Heap;
+        use core::{
+            alloc::{GlobalAlloc, Layout},
+            ops::Deref,
+            ptr::NonNull,
+        };
+
+        const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024; // 16 MB
+        const ORDER: usize = 32;
+
+        /// Global heap allocator
+        ///
+        /// Available after `memory::init()`.
+        #[global_allocator]
+        static HEAP_ALLOCATOR: LockedHeap<ORDER> = LockedHeap::<ORDER>::new();
+
+        /// Initialize the global heap allocator.
+        pub fn init() {
+            const MACHINE_ALIGN: usize = core::mem::size_of::<usize>();
+            const HEAP_BLOCK: usize = KERNEL_HEAP_SIZE / MACHINE_ALIGN;
+            static mut HEAP: [usize; HEAP_BLOCK] = [0; HEAP_BLOCK];
+            let heap_start = unsafe { HEAP.as_ptr() as usize };
+            unsafe {
+                HEAP_ALLOCATOR
+                    .lock()
+                    .init(heap_start, HEAP_BLOCK * MACHINE_ALIGN);
+            }
+            info!(
+                "Heap init end: {:#x?}",
+                heap_start..heap_start + KERNEL_HEAP_SIZE
+            );
+        }
+
+        pub struct LockedHeap<const ORDER: usize>(Mutex<Heap<ORDER>>);
+
+        impl<const ORDER: usize> LockedHeap<ORDER> {
+            /// Creates an empty heap
+            pub const fn new() -> Self {
+                LockedHeap(Mutex::new(Heap::<ORDER>::new()))
+            }
+        }
+
+        impl<const ORDER: usize> Deref for LockedHeap<ORDER> {
+            type Target = Mutex<Heap<ORDER>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeap<ORDER> {
+            unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+                self.0
+                    .lock()
+                    .alloc(layout)
+                    .ok()
+                    .map_or(core::ptr::null_mut::<u8>(), |allocation| allocation.as_ptr())
+            }
+
+            unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+                self.0.lock().dealloc(NonNull::new_unchecked(ptr), layout)
+            }
+        }
+    } else {
+        pub fn init() {}
+    }
+}
+
+#[cfg(feature = "hypervisor")]
+mod rvm_extern_fn {
+    use super::*;
+
+    #[rvm::extern_fn(alloc_frame)]
+    fn rvm_alloc_frame() -> Option<usize> {
+        hal_frame_alloc()
+    }
+
+    #[rvm::extern_fn(dealloc_frame)]
+    fn rvm_dealloc_frame(paddr: usize) {
+        hal_frame_dealloc(&paddr)
+    }
+
+    #[rvm::extern_fn(phys_to_virt)]
+    fn rvm_phys_to_virt(paddr: usize) -> usize {
+        // 示意，这个常量已经没了
+        // pub const PHYSICAL_MEMORY_OFFSET: usize = KERNEL_OFFSET - PHYS_MEMORY_BASE;
+        paddr + PHYSICAL_MEMORY_OFFSET
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[rvm::extern_fn(is_host_timer_interrupt)]
+    fn rvm_is_host_timer_interrupt(vector: u8) -> bool {
+        vector == 32 // IRQ0 + Timer in kernel-hal-bare/src/arch/x86_64/interrupt.rs
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[rvm::extern_fn(is_host_serial_interrupt)]
+    fn rvm_is_host_serial_interrupt(vector: u8) -> bool {
+        vector == 36 // IRQ0 + COM1 in kernel-hal-bare/src/arch/x86_64/interrupt.rs
+    }
+}

--- a/zCore/src/platform/aarch64/consts.rs
+++ b/zCore/src/platform/aarch64/consts.rs
@@ -1,8 +1,15 @@
 // aarch64
 
-pub const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024; // 32 MB
+use spin::Once;
+
+static OFFSET: Once<usize> = Once::new();
 
 #[inline]
-pub fn phys_memory_base() -> usize {
-    kernel_hal::arch::config::PHYS_MEMORY_BASE
+pub(super) fn save_offset(offset: usize) {
+    OFFSET.call_once(|| offset);
+}
+
+#[inline]
+pub fn phys_to_virt_offset() -> usize {
+    *OFFSET.wait()
 }

--- a/zCore/src/platform/aarch64/entry.rs
+++ b/zCore/src/platform/aarch64/entry.rs
@@ -1,3 +1,4 @@
+use super::consts::save_offset;
 use kernel_hal::KernelConfig;
 use rayboot::Aarch64BootInfo;
 core::arch::global_asm!(include_str!("space.s"));
@@ -24,6 +25,7 @@ extern "C" fn rust_main(boot_info: &'static Aarch64BootInfo) -> ! {
         gic_base: boot_info.gic_base,
         phys_to_virt_offset: boot_info.offset,
     };
+    save_offset(boot_info.offset);
     crate::primary_main(config);
     unreachable!()
 }

--- a/zCore/src/platform/libos/consts.rs
+++ b/zCore/src/platform/libos/consts.rs
@@ -1,4 +1,1 @@
-#[inline]
-pub fn phys_memory_base() -> usize {
-    0
-}
+//! Nothing

--- a/zCore/src/platform/mod.rs
+++ b/zCore/src/platform/mod.rs
@@ -14,4 +14,4 @@ cfg_if! {
     }
 }
 
-pub use arch::consts;
+pub use arch::consts::*;

--- a/zCore/src/platform/riscv/consts.rs
+++ b/zCore/src/platform/riscv/consts.rs
@@ -1,17 +1,14 @@
 // RISCV
 
-/// 内核堆容量。
-pub const KERNEL_HEAP_SIZE: usize = 80 * 1024 * 1024; // 80 MB
-
 /// 内核每个硬件线程的栈页数。
 pub const STACK_PAGES_PER_HART: usize = 32;
 
 /// 最大的对称多核硬件线程数量。
-pub const MAX_HART_NUM: usize = 8;
+pub const MAX_HART_NUM: usize = 4;
 
 #[inline]
-pub fn phys_memory_base() -> usize {
-    kernel_mem_info().paddr_base
+pub fn phys_to_virt_offset() -> usize {
+    kernel_mem_info().offset()
 }
 
 use spin::Once;

--- a/zCore/src/platform/x86/consts.rs
+++ b/zCore/src/platform/x86/consts.rs
@@ -1,8 +1,1 @@
-// x86_64
-
-pub const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024; // 16 MB
-
-#[inline]
-pub fn phys_memory_base() -> usize {
-    0
-}
+//! Nothing


### PR DESCRIPTION
内核堆分配器内存不足时从页帧分配器获取额外空间。

x86_64 和 libos 不会改，所以还是原来的。用编译选项通过 `target_arch` 自动选择。