### PR TITLE
Support configurable page sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,12 +731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "font8x8"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63201c624b8c8883921b1a1accc8916c4fa9dbfb15d122b26e4dde945b86bbf"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,7 +1043,7 @@ dependencies = [
  "tempfile",
  "tock-registers",
  "trapframe",
- "uefi",
+ "uefi 0.36.1",
  "x2apic",
  "x86",
  "x86-smpboot",
@@ -1514,19 +1508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayboot"
-version = "2.0.0"
-source = "git+https://github.com/Luchangcheng2333/rayboot?rev=b19c6c3#b19c6c3c8c43bf3a10bdefbe9c4a211f558d5555"
-dependencies = [
- "bit_field",
- "bitflags 1.3.2",
- "font8x8",
- "log",
- "serde",
- "spinning_top",
-]
-
-[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,10 +1534,9 @@ dependencies = [
 [[package]]
 name = "rboot"
 version = "0.2.0"
-source = "git+https://github.com/rcore-os/rboot.git?rev=bf91bac#bf91bac237c76ecb1fa766090f893dbaf15f73a3"
 dependencies = [
  "log",
- "uefi",
+ "uefi 0.40.0",
  "x86_64",
  "xmas-elf 0.10.0",
 ]
@@ -1807,9 +1787,6 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
-dependencies = [
- "serde_derive",
-]
 
 [[package]]
 name = "serde_derive"
@@ -1900,15 +1877,6 @@ name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "spinning_top"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
 ]
@@ -2107,7 +2075,23 @@ dependencies = [
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.13.0",
+ "uguid",
+]
+
+[[package]]
+name = "uefi"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2422138a1c4483f5d04081281ec841fb17f88cf1e2263b3b860fd455ab3a8d52"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.0",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw 0.16.0",
  "uguid",
 ]
 
@@ -2127,6 +2111,16 @@ name = "uefi-raw"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+dependencies = [
+ "bitflags 2.13.1",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b86018f5a44661f30db808298ccfcbe326279239c4d17a347c5476065ff72c0"
 dependencies = [
  "bitflags 2.13.1",
  "uguid",
@@ -2601,7 +2595,6 @@ dependencies = [
  "log",
  "page-table",
  "r0",
- "rayboot",
  "rboot",
  "rcore-fs",
  "rcore-fs-hostfs",

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -15,6 +15,11 @@ virtio = ["virtio-drivers"]
 loopback = []
 no-pci = []
 
+# page size configuration
+page-4k = []
+page-16k = []
+page-64k = []
+
 # special drivers for hardwares
 
 allwinner = ["d1-pac"]

--- a/drivers/src/bus/mod.rs
+++ b/drivers/src/bus/mod.rs
@@ -17,7 +17,12 @@ unsafe extern "C" {
     fn drivers_virt_to_phys(vaddr: VirtAddr) -> PhysAddr;
 }
 
-pub const PAGE_SIZE: usize = 4096;
+#[cfg(feature = "page-16k")]
+pub const PAGE_SIZE: usize = 0x4000;
+#[cfg(all(feature = "page-64k", not(feature = "page-16k")))]
+pub const PAGE_SIZE: usize = 0x1_0000;
+#[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+pub const PAGE_SIZE: usize = 0x1000;
 
 type VirtAddr = usize;
 type PhysAddr = usize;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -4,6 +4,9 @@
 #![deny(warnings)]
 #![feature(doc_cfg)]
 
+#[cfg(all(feature = "page-16k", feature = "page-64k"))]
+compile_error!("Features `page-16k` and `page-64k` are mutually exclusive.");
+
 extern crate alloc;
 
 #[macro_use]

--- a/drivers/src/net/mod.rs
+++ b/drivers/src/net/mod.rs
@@ -72,7 +72,12 @@ unsafe extern "C" {
     fn drivers_timer_now_as_micros() -> u64;
 }
 
-pub const PAGE_SIZE: usize = 4096;
+#[cfg(feature = "page-16k")]
+pub const PAGE_SIZE: usize = 0x4000;
+#[cfg(all(feature = "page-64k", not(feature = "page-16k")))]
+pub const PAGE_SIZE: usize = 0x1_0000;
+#[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+pub const PAGE_SIZE: usize = 0x1000;
 
 type VirtAddr = usize;
 type PhysAddr = usize;

--- a/drivers/src/nvme/nvme_queue.rs
+++ b/drivers/src/nvme/nvme_queue.rs
@@ -114,7 +114,12 @@ unsafe extern "C" {
     fn drivers_timer_now_as_micros() -> u64;
 }
 
-pub const PAGE_SIZE: usize = 4096;
+#[cfg(feature = "page-16k")]
+pub const PAGE_SIZE: usize = 0x4000;
+#[cfg(all(feature = "page-64k", not(feature = "page-16k")))]
+pub const PAGE_SIZE: usize = 0x1_0000;
+#[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+pub const PAGE_SIZE: usize = 0x1000;
 
 type VirtAddr = usize;
 type PhysAddr = usize;

--- a/kernel-hal/Cargo.toml
+++ b/kernel-hal/Cargo.toml
@@ -28,6 +28,11 @@ board-c910light = []
 link-user-img = []
 # Enable extra page table falgs for T-Head CPU with MAEE on
 thead-maee = []
+# Page size configuration
+page-4k = ["zcore-drivers/page-4k"]
+page-16k = ["zcore-drivers/page-16k"]
+page-64k = ["zcore-drivers/page-64k"]
+
 # Disable PCI
 no-pci = ["zcore-drivers/no-pci"]
 # Enable allwinner drivers

--- a/kernel-hal/src/bare/arch/aarch64/mem.rs
+++ b/kernel-hal/src/bare/arch/aarch64/mem.rs
@@ -9,7 +9,7 @@ extern "C" {
 
 pub fn free_pmem_regions() -> Vec<Range<PhysAddr>> {
     let mut regions = Vec::new();
-    let start = ekernel as *const () as usize & PHYS_ADDR_MASK;
+    let start = crate::addr::align_up(crate::mem::virt_to_phys(ekernel as *const () as usize));
     regions.push(start as PhysAddr..PHYS_MEMORY_END as PhysAddr);
     regions
 }

--- a/kernel-hal/src/bare/arch/aarch64/vm.rs
+++ b/kernel-hal/src/bare/arch/aarch64/vm.rs
@@ -1,7 +1,11 @@
 use crate::hal_fn::mem::phys_to_virt;
 use crate::imp::config::*;
 use crate::sync::Mutex;
-use crate::utils::page_table::{GenericPTE, PageTableImpl, PageTableLevel4};
+#[cfg(feature = "page-64k")]
+use crate::utils::page_table::PageTableLevel3;
+#[cfg(not(feature = "page-64k"))]
+use crate::utils::page_table::PageTableLevel4;
+use crate::utils::page_table::{GenericPTE, PageTableImpl};
 use crate::MMUFlags;
 use crate::{PhysAddr, VirtAddr, KCONFIG};
 use core::fmt::{Debug, Formatter, Result};
@@ -30,10 +34,16 @@ fn init_kernel_page_table() -> PagingResult<PageTable> {
 
     let mut pt = PageTable::new();
     let mut map_range = |start: VirtAddr, end: VirtAddr, flags: MMUFlags| -> PagingResult {
+        let aligned_start = crate::addr::align_down(start);
+        let aligned_end = crate::addr::align_up(end);
+        let size = aligned_end - aligned_start;
+        if size == 0 {
+            return Ok(());
+        }
         pt.map_cont(
-            crate::addr::align_down(start),
-            crate::addr::align_up(end - start),
-            start - KCONFIG.phys_to_virt_offset,
+            aligned_start,
+            size,
+            aligned_start - KCONFIG.phys_to_virt_offset,
             flags,
         )
     };
@@ -101,10 +111,8 @@ fn init_kernel_page_table() -> PagingResult<PageTable> {
 
 pub fn init() {
     let mut pt = KERNEL_PT.lock();
-    info!("initialized kernel page table @ {:#x}", pt.table_phys());
     unsafe {
         pt.activate();
-        TTBR0_EL1.set(0);
         flush_tlb_all();
     }
 }
@@ -120,16 +128,82 @@ pub fn flush_tlb_all() {
     }
 }
 
+#[unsafe(naked)]
+unsafe extern "C" fn switch_kernel_table_trampoline(
+    _new_ttbr1: u64,
+    _tcr_transition: u64,
+    _final_tcr: u64,
+    _target_virt_pc: usize,
+) {
+    core::arch::naked_asm!(
+        "msr ttbr1_el1, x0",
+        "msr tcr_el1, x1",
+        "isb",
+        "tlbi vmalle1",
+        "dsb sy",
+        "isb",
+        "mov x0, x2",
+        "br x3",
+    );
+}
+
+#[unsafe(naked)]
+unsafe extern "C" fn after_switch_trampoline(_final_tcr: u64) {
+    core::arch::naked_asm!(
+        "msr tcr_el1, x0",
+        "msr ttbr0_el1, xzr",
+        "isb",
+        "tlbi vmalle1",
+        "dsb sy",
+        "isb",
+        "ret",
+    );
+}
+
 hal_fn_impl! {
     impl mod crate::hal_fn::vm {
         fn activate_paging(vmtoken: PhysAddr) {
             let check_if_user = (vmtoken & USER_TABLE_FLAG) != 0;
             let vmtoken = vmtoken & PHYS_ADDR_MASK;
             info!("set {} page_table @ {:#x}", if check_if_user { "user" } else { "kernel" }, vmtoken);
+
+            // TCR_EL1 base for the configured granule, *without* IPS.
+            #[cfg(feature = "page-16k")]
+            const TCR_BASE: u64 = 0x7510_b510;
+            #[cfg(feature = "page-64k")]
+            const TCR_BASE: u64 = 0xf510_7510;
+            #[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+            const TCR_BASE: u64 = 0xb510_3510;
+
+            let ips = ID_AA64MMFR0_EL1.read(ID_AA64MMFR0_EL1::PARange);
+            let tcr = TCR_BASE | (ips << 32);
+
             if check_if_user {
                 TTBR0_EL1.set(vmtoken as _);
+                unsafe {
+                    core::arch::asm!("msr tcr_el1, {0}", in(reg) tcr);
+                    core::arch::asm!("isb");
+                }
             } else {
-                TTBR1_EL1.set(vmtoken as _);
+                let ttbr0 = TTBR0_EL1.get();
+                if ttbr0 != 0 {
+                    let current_tcr: u64;
+                    unsafe {
+                        core::arch::asm!("mrs {0}, tcr_el1", out(reg) current_tcr);
+                    }
+                    let tcr_transition = (tcr & 0xffff_ffff_ffff_0000) | (current_tcr & 0x0000_ffff);
+                    let fn_phys = (switch_kernel_table_trampoline as *const () as usize) - KCONFIG.phys_to_virt_offset;
+                    let trampoline: unsafe extern "C" fn(u64, u64, u64, usize) = unsafe { core::mem::transmute(fn_phys) };
+                    unsafe {
+                        trampoline(vmtoken as u64, tcr_transition, tcr, after_switch_trampoline as *const () as usize);
+                    }
+                } else {
+                    TTBR1_EL1.set(vmtoken as _);
+                    unsafe {
+                        core::arch::asm!("msr tcr_el1, {0}", in(reg) tcr);
+                        core::arch::asm!("isb");
+                    }
+                }
             }
             flush_tlb_all();
         }
@@ -148,7 +222,7 @@ hal_fn_impl! {
                         tlbi vaae1is, {0}
                         dsb ish
                         isb",
-                        in(reg) vaddr >> 12
+                        in(reg) vaddr >> crate::PAGE_SIZE_LOG2
                     );
                 }
             } else {
@@ -157,9 +231,10 @@ hal_fn_impl! {
         }
 
         fn pt_clone_kernel_space(dst_pt_root: PhysAddr, src_pt_root: PhysAddr) {
-            let entry_range = 0x100..0x200;  // 0xffff_0000_8000_0000..0xffff_0000_c000_0000
-            let dst_table = unsafe { core::slice::from_raw_parts_mut(phys_to_virt(dst_pt_root) as *mut AARCH64PTE, 512) };
-            let src_table = unsafe { core::slice::from_raw_parts(phys_to_virt(src_pt_root) as *const AARCH64PTE, 512) };
+            let entry_count = crate::PAGE_SIZE / core::mem::size_of::<usize>();
+            let entry_range = (entry_count / 2)..entry_count;
+            let dst_table = unsafe { core::slice::from_raw_parts_mut(phys_to_virt(dst_pt_root) as *mut AARCH64PTE, entry_count) };
+            let src_table = unsafe { core::slice::from_raw_parts(phys_to_virt(src_pt_root) as *const AARCH64PTE, entry_count) };
             for i in entry_range {
                 dst_table[i] = src_table[i];
                 if dst_table[i].is_unused() {
@@ -294,7 +369,7 @@ impl From<PTF> for MMUFlags {
             if !f.contains(PTF::UXN) {
                 ret |= Self::EXECUTE;
             }
-        } else if f.intersects(PTF::PXN) {
+        } else if !f.intersects(PTF::PXN) {
             ret |= Self::EXECUTE;
         }
         if f.mem_type() == MemType::Device {
@@ -352,5 +427,20 @@ impl Debug for AARCH64PTE {
     }
 }
 
-/// Sv48: Page-Based 48-bit Virtual-Memory System.
+// Number of levels needed to cover a 48-bit VA at each granule:
+//
+//     4K:  12 + 4*9  ≥ 48 → 4 levels (root = VA[47:39], 9 bits)
+//     16K: 14 + 4*11 ≥ 48 → 4 levels (root = VA[47],    1 bit)
+//     64K: 16 + 3*13 ≥ 48 → 3 levels (root = VA[47:42], 6 bits)
+//
+// A 48-bit VA is not optional: `phys_to_virt` offsets physical addresses into
+// the TTBR1 half, and the resulting direct-map addresses (e.g. the UART at
+// 0xffff_7f03_c445_b800) have VA[47] = 0. Narrowing to a 47-bit VA (T1SZ = 17,
+// 3-level) makes those addresses untranslatable, faulting on the first access
+// after the kernel table is installed.
+//
+// The narrow root indices are handled by `root_index` in `utils::page_table`.
+#[cfg(not(feature = "page-64k"))]
 pub type PageTable = PageTableImpl<PageTableLevel4, AARCH64PTE>;
+#[cfg(feature = "page-64k")]
+pub type PageTable = PageTableImpl<PageTableLevel3, AARCH64PTE>;

--- a/kernel-hal/src/common/context.rs
+++ b/kernel-hal/src/common/context.rs
@@ -118,7 +118,7 @@ impl TrapReason {
     #[cfg(target_arch = "aarch64")]
     pub fn from(esr: usize) -> Self {
         // TODO: check if is right
-        use crate::{Fault, Info, Kind, Source, Syndrome};
+        use crate::{Info, Kind, Source, Syndrome};
         use cortex_a::registers::{ESR_EL1, FAR_EL1};
         use tock_registers::interfaces::Readable;
 
@@ -135,10 +135,9 @@ impl TrapReason {
                     FAR_EL1.get() as _,
                     MMUFlags::READ | MMUFlags::WRITE | MMUFlags::USER,
                 ),
-                Syndrome::InstructionAbort {
-                    kind: Fault::Permission,
-                    level: _,
-                } => Self::PageFault(FAR_EL1.get() as _, MMUFlags::EXECUTE | MMUFlags::USER),
+                Syndrome::InstructionAbort { kind: _, level: _ } => {
+                    Self::PageFault(FAR_EL1.get() as _, MMUFlags::EXECUTE | MMUFlags::USER)
+                }
                 Syndrome::PCAlignmentFault | Syndrome::SpAlignmentFault => Self::UnalignedAccess,
                 _ => Self::GernelFault(esr as usize),
             },

--- a/kernel-hal/src/common/defs.rs
+++ b/kernel-hal/src/common/defs.rs
@@ -194,7 +194,23 @@ cfg_if! {
     }
 }
 
-/// The smallest size of a page (4K).
-pub const PAGE_SIZE: usize = super::vm::PageSize::Size4K as usize;
+#[cfg(all(feature = "page-16k", feature = "page-64k"))]
+compile_error!("Features `page-16k` and `page-64k` are mutually exclusive.");
+
+/// The base size of a page.
+#[cfg(feature = "page-16k")]
+pub const PAGE_SIZE: usize = 0x4000;
+#[cfg(feature = "page-16k")]
+pub const PAGE_SIZE_LOG2: usize = 14;
+
+#[cfg(all(feature = "page-64k", not(feature = "page-16k")))]
+pub const PAGE_SIZE: usize = 0x1_0000;
+#[cfg(all(feature = "page-64k", not(feature = "page-16k")))]
+pub const PAGE_SIZE_LOG2: usize = 16;
+
+#[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+pub const PAGE_SIZE: usize = 0x1000;
+#[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+pub const PAGE_SIZE_LOG2: usize = 12;
 
 pub use super::addr::{DevVAddr, PhysAddr, VirtAddr};

--- a/kernel-hal/src/common/vm.rs
+++ b/kernel-hal/src/common/vm.rs
@@ -27,16 +27,22 @@ impl<T> IgnoreNotMappedErr for PagingResult<T> {
     }
 }
 
-/// Possible page size (4K, 2M, 1G).
+/// Possible page size.
 #[repr(usize)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[allow(clippy::enum_clike_unportable_variant)]
 pub enum PageSize {
     Size4K = 0x1000,
+    Size16K = 0x4000,
+    Size64K = 0x1_0000,
     Size2M = 0x20_0000,
+    Size32M = 0x200_0000,
+    Size512M = 0x2000_0000,
     Size1G = 0x4000_0000,
+    Size64G = 0x10_0000_0000,
 }
 
-/// A 4K, 2M or 1G size page.
+/// A sized page.
 #[derive(Debug, Copy, Clone)]
 pub struct Page {
     pub vaddr: VirtAddr,
@@ -44,6 +50,51 @@ pub struct Page {
 }
 
 impl PageSize {
+    pub const BASE: Self = {
+        #[cfg(feature = "page-16k")]
+        {
+            Self::Size16K
+        }
+        #[cfg(feature = "page-64k")]
+        {
+            Self::Size64K
+        }
+        #[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+        {
+            Self::Size4K
+        }
+    };
+
+    pub const HUGE_L2: Self = {
+        #[cfg(feature = "page-16k")]
+        {
+            Self::Size32M
+        }
+        #[cfg(feature = "page-64k")]
+        {
+            Self::Size512M
+        }
+        #[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+        {
+            Self::Size2M
+        }
+    };
+
+    pub const HUGE_L3: Self = {
+        #[cfg(feature = "page-16k")]
+        {
+            Self::Size64G
+        }
+        #[cfg(feature = "page-64k")]
+        {
+            Self::Size512M
+        }
+        #[cfg(not(any(feature = "page-16k", feature = "page-64k")))]
+        {
+            Self::Size1G
+        }
+    };
+
     pub const fn is_aligned(self, addr: usize) -> bool {
         self.page_offset(addr) == 0
     }
@@ -57,7 +108,7 @@ impl PageSize {
     }
 
     pub const fn is_huge(self) -> bool {
-        matches!(self, Self::Size1G | Self::Size2M)
+        self as usize > Self::BASE as usize
     }
 }
 
@@ -112,18 +163,18 @@ pub trait GenericPageTable: Sync + Send {
         if flags.contains(MMUFlags::HUGE_PAGE) {
             while vaddr < end_vaddr {
                 let remains = end_vaddr - vaddr;
-                let page_size = if remains >= PageSize::Size1G as usize
-                    && PageSize::Size1G.is_aligned(vaddr)
-                    && PageSize::Size1G.is_aligned(paddr)
+                let page_size = if remains >= PageSize::HUGE_L3 as usize
+                    && PageSize::HUGE_L3.is_aligned(vaddr)
+                    && PageSize::HUGE_L3.is_aligned(paddr)
                 {
-                    PageSize::Size1G
-                } else if remains >= PageSize::Size2M as usize
-                    && PageSize::Size2M.is_aligned(vaddr)
-                    && PageSize::Size2M.is_aligned(paddr)
+                    PageSize::HUGE_L3
+                } else if remains >= PageSize::HUGE_L2 as usize
+                    && PageSize::HUGE_L2.is_aligned(vaddr)
+                    && PageSize::HUGE_L2.is_aligned(paddr)
                 {
-                    PageSize::Size2M
+                    PageSize::HUGE_L2
                 } else {
-                    PageSize::Size4K
+                    PageSize::BASE
                 };
                 let page = Page::new_aligned(vaddr, page_size);
                 self.map(page, paddr, flags)?;
@@ -132,7 +183,7 @@ pub trait GenericPageTable: Sync + Send {
             }
         } else {
             while vaddr < end_vaddr {
-                let page_size = PageSize::Size4K;
+                let page_size = PageSize::BASE;
                 let page = Page::new_aligned(vaddr, page_size);
                 self.map(page, paddr, flags)?;
                 vaddr += page_size as usize;

--- a/kernel-hal/src/utils/page_table.rs
+++ b/kernel-hal/src/utils/page_table.rs
@@ -1,5 +1,7 @@
 use crate::sync::Mutex;
-use crate::{common::vm::*, mem::PhysFrame, MMUFlags, PhysAddr, VirtAddr};
+use crate::{
+    common::vm::*, mem::PhysFrame, MMUFlags, PhysAddr, VirtAddr, PAGE_SIZE, PAGE_SIZE_LOG2,
+};
 use alloc::vec::Vec;
 use core::{fmt::Debug, marker::PhantomData, slice};
 
@@ -71,26 +73,30 @@ impl<L: PageTableLevel, PTE: GenericPTE> PageTableImpl<L, PTE> {
             table_of_mut::<PTE>(self.table_phys())
         } else if L::LEVEL == 4 {
             let p4 = table_of_mut::<PTE>(self.table_phys());
-            let p4e = &mut p4[p4_index(vaddr)];
+            let p4e = &mut p4[root_index(vaddr, 4)];
             next_table_mut(p4e)?
         } else {
             unreachable!()
         };
 
-        let p3e = &mut p3[p3_index(vaddr)];
+        let p3e = &mut p3[if L::LEVEL == 3 {
+            root_index(vaddr, 3)
+        } else {
+            p3_index(vaddr)
+        }];
         if p3e.is_leaf() {
-            return Ok((p3e, PageSize::Size1G));
+            return Ok((p3e, PageSize::HUGE_L3));
         }
 
         let p2 = next_table_mut(p3e)?;
         let p2e = &mut p2[p2_index(vaddr)];
         if p2e.is_leaf() {
-            return Ok((p2e, PageSize::Size2M));
+            return Ok((p2e, PageSize::HUGE_L2));
         }
 
         let p1 = next_table_mut(p2e)?;
         let p1e = &mut p1[p1_index(vaddr)];
-        Ok((p1e, PageSize::Size4K))
+        Ok((p1e, PageSize::BASE))
     }
 
     fn get_entry_mut_or_create(&mut self, page: Page) -> PagingResult<&mut PTE> {
@@ -99,20 +105,24 @@ impl<L: PageTableLevel, PTE: GenericPTE> PageTableImpl<L, PTE> {
             table_of_mut::<PTE>(self.table_phys())
         } else if L::LEVEL == 4 {
             let p4 = table_of_mut::<PTE>(self.table_phys());
-            let p4e = &mut p4[p4_index(vaddr)];
+            let p4e = &mut p4[root_index(vaddr, 4)];
             next_table_mut_or_create(p4e, || self.alloc_intrm_table())?
         } else {
             unreachable!()
         };
 
-        let p3e = &mut p3[p3_index(vaddr)];
-        if page.size == PageSize::Size1G {
+        let p3e = &mut p3[if L::LEVEL == 3 {
+            root_index(vaddr, 3)
+        } else {
+            p3_index(vaddr)
+        }];
+        if page.size == PageSize::HUGE_L3 {
             return Ok(p3e);
         }
 
         let p2 = next_table_mut_or_create(p3e, || self.alloc_intrm_table())?;
         let p2e = &mut p2[p2_index(vaddr)];
-        if page.size == PageSize::Size2M {
+        if page.size == PageSize::HUGE_L2 {
             return Ok(p2e);
         }
 
@@ -131,10 +141,10 @@ impl<L: PageTableLevel, PTE: GenericPTE> PageTableImpl<L, PTE> {
     ) {
         let mut n = 0;
         for (i, entry) in table.iter().enumerate() {
-            let vaddr = start_vaddr + (i << (12 + (3 - level) * 9));
+            let vaddr = start_vaddr + (i << (PAGE_SIZE_LOG2 + (L::LEVEL - 1 - level) * INDEX_BITS));
             if entry.is_present() {
                 func(level, i, vaddr, entry);
-                if level < 3 && !entry.is_leaf() {
+                if level < L::LEVEL - 1 && !entry.is_leaf() {
                     let table_entry = next_table_mut(entry).unwrap();
                     self.walk(table_entry, level + 1, vaddr, limit, func);
                 }
@@ -274,22 +284,58 @@ impl<L: PageTableLevel, PTE: GenericPTE> GenericPageTable for PageTableImpl<L, P
     }
 }
 
-const ENTRY_COUNT: usize = 512;
+const ENTRY_COUNT: usize = PAGE_SIZE / core::mem::size_of::<usize>();
+const INDEX_BITS: usize = ENTRY_COUNT.trailing_zeros() as usize;
 
-const fn p4_index(vaddr: usize) -> usize {
-    (vaddr >> (12 + 27)) & (ENTRY_COUNT - 1)
+/// Translatable virtual address width, in bits.
+///
+/// Only used to narrow the *root* table index below. Configurations whose root
+/// still consumes a full `INDEX_BITS` (4K/4-level, RISC-V Sv39/Sv48) are
+/// unaffected by the clamp in [`root_index_bits`].
+const VA_BITS: usize = 48;
+
+/// Bit-shift of the root table's index for a table with `level` levels.
+const fn root_shift(level: usize) -> usize {
+    PAGE_SIZE_LOG2 + (level - 1) * INDEX_BITS
 }
 
+/// Number of index bits the *root* table actually uses.
+///
+/// The lower levels always consume `INDEX_BITS`, but the root only covers
+/// whatever is left of the virtual address, which can be fewer. With a 16K
+/// granule and a 48-bit VA, for example, the walk is `14 + 3*11` and the root
+/// (level 0) is selected by VA[47] alone — a single bit. Masking the root index
+/// with the full `INDEX_BITS` there would place entries at index 2047 while the
+/// hardware page-table walker reads index 1, so every mapping would silently
+/// resolve to a zero descriptor.
+const fn root_index_bits(level: usize) -> usize {
+    let shift = root_shift(level);
+    let remaining = VA_BITS - shift;
+    if remaining < INDEX_BITS {
+        remaining
+    } else {
+        INDEX_BITS
+    }
+}
+
+/// Index of `vaddr` into the root table of a table with `level` levels.
+const fn root_index(vaddr: usize, level: usize) -> usize {
+    (vaddr >> root_shift(level)) & ((1 << root_index_bits(level)) - 1)
+}
+
+// The level-4 (root) index is computed by `root_index`, which additionally
+// clamps the mask to the bits the hardware walker actually decodes.
+
 const fn p3_index(vaddr: usize) -> usize {
-    (vaddr >> (12 + 18)) & (ENTRY_COUNT - 1)
+    (vaddr >> (PAGE_SIZE_LOG2 + 2 * INDEX_BITS)) & (ENTRY_COUNT - 1)
 }
 
 const fn p2_index(vaddr: usize) -> usize {
-    (vaddr >> (12 + 9)) & (ENTRY_COUNT - 1)
+    (vaddr >> (PAGE_SIZE_LOG2 + INDEX_BITS)) & (ENTRY_COUNT - 1)
 }
 
 const fn p1_index(vaddr: usize) -> usize {
-    (vaddr >> 12) & (ENTRY_COUNT - 1)
+    (vaddr >> PAGE_SIZE_LOG2) & (ENTRY_COUNT - 1)
 }
 
 fn table_of<'a, E>(paddr: PhysAddr) -> &'a [E] {

--- a/linux-object/Cargo.toml
+++ b/linux-object/Cargo.toml
@@ -9,6 +9,9 @@ description = "Linux kernel objects"
 
 [features]
 mock-disk = []
+page-4k = ["zircon-object/page-4k", "kernel-hal/page-4k"]
+page-16k = ["zircon-object/page-16k", "kernel-hal/page-16k"]
+page-64k = ["zircon-object/page-64k", "kernel-hal/page-64k"]
 
 [dependencies]
 async-trait = "0.1.92"

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -26,6 +26,9 @@ default = ["libos", "linux", "zircon"]
 linux = ["linux-object", "linux-syscall"]
 zircon = ["zircon-syscall", "xmas-elf"]
 libos = ["kernel-hal/libos", "zircon-object/aspace-separate"]
+page-4k = ["kernel-hal/page-4k", "zircon-object/page-4k", "linux-object?/page-4k"]
+page-16k = ["kernel-hal/page-16k", "zircon-object/page-16k", "linux-object?/page-16k"]
+page-64k = ["kernel-hal/page-64k", "zircon-object/page-64k", "linux-object?/page-64k"]
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -208,7 +208,7 @@ impl QemuArgs {
             }
             Arch::X86_64 => todo!(),
             Arch::Aarch64 => {
-                fs::copy(obj, INNER.join("disk").join("os")).unwrap();
+                fs::copy(&obj, INNER.join("disk").join("os")).unwrap();
                 qemu.args(["-machine", "virt"])
                     .args(["-cpu", "cortex-a72"])
                     .arg("-bios")

--- a/xtask/src/linux/image.rs
+++ b/xtask/src/linux/image.rs
@@ -1,5 +1,5 @@
-use crate::{commands::wget, Arch, PROJECT_DIR};
-use os_xtask_utils::{dir, CommandExt, Qemu, Tar};
+use crate::{Arch, PROJECT_DIR};
+use os_xtask_utils::{dir, CommandExt, Ext, Qemu};
 use std::{fs, path::Path};
 
 impl super::LinuxRootfs {
@@ -10,24 +10,31 @@ impl super::LinuxRootfs {
         // 镜像路径
         let inner = PROJECT_DIR.join("zCore");
         let image = inner.join(format!("{arch}.img", arch = self.0.name()));
-        // aarch64 还需要下载 firmware
+        // aarch64 升级为 rboot
         if let Arch::Aarch64 = self.0 {
-            const URL: &str = "https://github.com/Luchangcheng2333/rayboot/releases/download/2.0.0/aarch64_firmware.tar.gz";
-            let aarch64_tar = self.0.origin().join("Aarch64_firmware.zip");
-            wget(URL, &aarch64_tar);
-
-            let fw_dir = self.0.target().join("firmware");
-            dir::clear(&fw_dir).unwrap();
-            Tar::xf(&aarch64_tar, Some(&fw_dir)).invoke();
-
             let boot_dir = inner.join("disk").join("EFI").join("Boot");
             dir::clear(&boot_dir).unwrap();
-            fs::copy(
-                fw_dir.join("aarch64_uefi.efi"),
-                boot_dir.join("bootaa64.efi"),
-            )
-            .unwrap();
-            fs::copy(fw_dir.join("Boot.json"), boot_dir.join("Boot.json")).unwrap();
+
+            Ext::new("cargo")
+                .arg("build")
+                .arg("--manifest-path")
+                .arg("rboot/Cargo.toml")
+                .arg("--target")
+                .arg("aarch64-unknown-uefi")
+                .arg("-Zbuild-std=core,alloc")
+                .arg("-Zbuild-std-features=compiler-builtins-mem")
+                .arg("--release")
+                .invoke();
+
+            let rboot_efi = PROJECT_DIR
+                .join("rboot")
+                .join("target")
+                .join("aarch64-unknown-uefi")
+                .join("release")
+                .join("rboot.efi");
+
+            fs::copy(&rboot_efi, boot_dir.join("bootaa64.efi")).unwrap();
+            fs::copy(inner.join("rboot.conf"), boot_dir.join("rboot.conf")).unwrap();
         }
         // 生成镜像
         fuse(self.path(), &image);

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -15,6 +15,11 @@ bench = false
 doc = false
 
 [features]
+# Page size configuration
+page-4k = ["kernel-hal/page-4k", "zcore-loader/page-4k", "zircon-object/page-4k", "linux-object?/page-4k"]
+page-16k = ["kernel-hal/page-16k", "zcore-loader/page-16k", "zircon-object/page-16k", "linux-object?/page-16k"]
+page-64k = ["kernel-hal/page-64k", "zcore-loader/page-64k", "zircon-object/page-64k", "linux-object?/page-64k"]
+
 # Print colorless logs
 colorless-log = []
 

--- a/zCore/Cargo.toml
+++ b/zCore/Cargo.toml
@@ -92,11 +92,11 @@ sbi-rt = { version = "0.0.2", features = ["legacy"] }
 
 # Bare-metal mode on aarch64
 [target.'cfg(all(target_os = "none", target_arch = "aarch64"))'.dependencies]
-rayboot = { git = "https://github.com/Luchangcheng2333/rayboot", rev = "b19c6c3" }
+rboot = { path = "../rboot", default-features = false }
 
 # Bare-metal mode on x86_64
 [target.'cfg(all(target_os = "none", target_arch = "x86_64"))'.dependencies]
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "88e871a5" }
 buddy_system_allocator = "0.8"
-rboot = { git = "https://github.com/rcore-os/rboot.git", rev = "bf91bac", default-features = false }
+rboot = { path = "../rboot", default-features = false }
 # rvm = { git = "https://github.com/rcore-os/RVM", rev = "e91d625", optional = true }

--- a/zCore/Makefile
+++ b/zCore/Makefile
@@ -260,13 +260,8 @@ endif
 
 .PHONY: justrun
 justrun: $(qemu_disk)
-ifeq ($(ARCH), x86_64)
 	$(sed) 's#initramfs=.*#initramfs=\\EFI\\zCore\\$(notdir $(user_img))#' $(esp)/EFI/Boot/rboot.conf
 	$(sed) 's#cmdline=.*#cmdline=$(CMDLINE)#' $(esp)/EFI/Boot/rboot.conf
-endif
-ifeq ($(ARCH), aarch64)
-	$(sed) 's#\"cmdline\":.*#\"cmdline\": \"$(CMDLINE)\",#' disk/EFI/Boot/Boot.json
-endif
 ifeq ($(PLATFORM), d1)
 	$(OBJCOPY) ../prebuilt/firmware/riscv/d1_fw_payload.elf --strip-all -O binary ./zcore_d1.bin
 	dd if=$(kernel_img) of=zcore_d1.bin bs=512 seek=2048
@@ -287,10 +282,8 @@ endif
 .PHONY: debugrun
 debugrun: $(qemu_disk)
 	cp .gdbinit_$(ARCH) .gdbinit
-ifeq ($(ARCH), x86_64)
 	$(sed) 's#initramfs=.*#initramfs=\\EFI\\zCore\\$(notdir $(user_img))#' $(esp)/EFI/Boot/rboot.conf
 	$(sed) 's#cmdline=.*#cmdline=$(CMDLINE)#' $(esp)/EFI/Boot/rboot.conf
-endif
 ifeq ($(ARCH), aarch64)
 	$(sed) 's#\"cmdline\":.*#\"cmdline\": \"$(CMDLINE)\",#' disk/EFI/Boot/Boot.json
 endif
@@ -326,20 +319,18 @@ clean:
 
 .PHONY: bootloader
 bootloader:
-ifeq ($(ARCH), x86_64)
 	@cd ../rboot && make build
-endif
 
 $(kernel_img): kernel bootloader
+	mkdir -p $(esp)/EFI/zCore $(esp)/EFI/Boot
+	cp rboot.conf $(esp)/EFI/Boot/rboot.conf
+	cp $(kernel_elf) $(esp)/EFI/zCore/zcore.elf
+	cp $(user_img) $(esp)/EFI/zCore/
 ifeq ($(ARCH), x86_64)
   ifeq ($(USER), 1)
 	make -C ../zircon-user
   endif
-	mkdir -p $(esp)/EFI/zCore $(esp)/EFI/Boot
 	cp ../rboot/target/x86_64-unknown-uefi/release/rboot.efi $(esp)/EFI/Boot/BootX64.efi
-	cp rboot.conf $(esp)/EFI/Boot/rboot.conf
-	cp $(kernel_elf) $(esp)/EFI/zCore/zcore.elf
-	cp $(user_img) $(esp)/EFI/zCore/
 else ifeq ($(ARCH), riscv64)
 	$(OBJCOPY) $(kernel_elf) --strip-all -O binary $@
 endif

--- a/zCore/src/memory.rs
+++ b/zCore/src/memory.rs
@@ -21,18 +21,11 @@ struct LockedHeap(Mutex<BuddyAllocator<27, UsizeBuddy, LinkedListBuddy>>);
 static HEAP: LockedHeap = LockedHeap(Mutex::new(BuddyAllocator::new()));
 
 /// 单页地址位数。
-const PAGE_BITS: usize = 12;
+const PAGE_BITS: usize = kernel_hal::PAGE_SIZE_LOG2;
 
-/// 为启动准备的初始内存。
-///
-/// 经测试，不同硬件的需求：
-///
-/// | machine         | memory
-/// | --------------- | -
-/// | qemu,virt SMP 1 |  16 KiB
-/// | qemu,virt SMP 4 |  32 KiB
-/// | allwinner,nezha | 256 KiB
-static mut MEMORY: [u8; 2 * 1024 * 1024] = [0u8; 2 * 1024 * 1024];
+#[repr(align(65536))]
+struct Memory([u8; 2 * 1024 * 1024]);
+static mut MEMORY: Memory = Memory([0u8; 2 * 1024 * 1024]);
 
 unsafe impl GlobalAlloc for LockedHeap {
     #[inline]
@@ -55,8 +48,8 @@ unsafe impl GlobalAlloc for LockedHeap {
 /// 初始化分配器，并将一个小的内存块注册到分配器中，用于启动需要的动态内存。
 pub fn init() {
     unsafe {
-        let start = core::ptr::addr_of_mut!(MEMORY).cast::<u8>();
-        let len = core::mem::size_of::<[u8; 2 * 1024 * 1024]>();
+        let start = core::ptr::addr_of_mut!(MEMORY.0).cast::<u8>();
+        let len = core::mem::size_of::<Memory>();
         log::info!("MEMORY = {:#?}", start..start.add(len));
         let mut heap = HEAP.0.lock();
         let ptr = NonNull::new_unchecked(start);
@@ -84,7 +77,7 @@ pub fn frame_alloc(frame_count: usize, align_log2: usize) -> Option<PhysAddr> {
     let (ptr, size) = HEAP
         .0
         .lock()
-        .allocate::<u8>(align_log2 << PAGE_BITS, unsafe {
+        .allocate::<u8>(align_log2 + PAGE_BITS, unsafe {
             NonZeroUsize::new_unchecked(frame_count << PAGE_BITS)
         })
         .ok()?;

--- a/zCore/src/memory_x86_64.rs
+++ b/zCore/src/memory_x86_64.rs
@@ -7,7 +7,7 @@ use kernel_hal::PhysAddr;
 
 type FrameAlloc = bitmap_allocator::BitAlloc16M; // max 64G
 
-const PAGE_BITS: usize = 12;
+const PAGE_BITS: usize = kernel_hal::PAGE_SIZE_LOG2;
 
 /// Global physical frame allocator
 static FRAME_ALLOCATOR: Mutex<FrameAlloc> = Mutex::new(FrameAlloc::DEFAULT);

--- a/zCore/src/platform/aarch64/entry.rs
+++ b/zCore/src/platform/aarch64/entry.rs
@@ -1,6 +1,6 @@
 use super::consts::save_offset;
 use kernel_hal::KernelConfig;
-use rayboot::Aarch64BootInfo;
+use rboot::Aarch64BootInfo;
 core::arch::global_asm!(include_str!("space.s"));
 
 #[unsafe(naked)]

--- a/zCore/src/platform/aarch64/linker.ld
+++ b/zCore/src/platform/aarch64/linker.ld
@@ -1,5 +1,5 @@
 ENTRY(_start)
-BASE_ADDRESS = 0xffff000040080000;
+BASE_ADDRESS = 0xffff800040080000;
 
 SECTIONS
 {
@@ -10,7 +10,7 @@ SECTIONS
         stext = .;
         *(.text.entry)
         *(.text .text.*)
-        . = ALIGN(4K);
+        . = ALIGN(64K);
         etext = .;
     }
 
@@ -18,7 +18,7 @@ SECTIONS
         srodata = .;
         *(.rodata .rodata.*)
         *(.srodata .srodata.*)
-        . = ALIGN(4K);
+        . = ALIGN(64K);
         erodata = .;
     }
 
@@ -26,20 +26,20 @@ SECTIONS
         sdata = .;
         *(.data .data.*)
         *(.sdata .sdata.*)
-        . = ALIGN(4K);
+        . = ALIGN(64K);
         edata = .;
     }
 
     .bss : {
         boot_stack = .;
         *(.bss.stack)
-        . = ALIGN(4K);
+        . = ALIGN(64K);
         boot_stack_top = .;
 
         sbss = .;
         *(.bss .bss.*)
         *(.sbss .sbss.*)
-        . = ALIGN(4K);
+        . = ALIGN(64K);
         ebss = .;
     }
 

--- a/zCore/src/platform/aarch64/space.s
+++ b/zCore/src/platform/aarch64/space.s
@@ -1,10 +1,10 @@
 .section .data
-.align 12
+.align 16
 sdata:
     .space 0x8000 // 32K
 
 .section .bss.stack
-.align 12
+.align 16
 boot_stack:
     .space 0x8000 // 32K
 boot_stack_top:

--- a/zircon-object/Cargo.toml
+++ b/zircon-object/Cargo.toml
@@ -15,6 +15,10 @@ aspace-separate = []
 elf = ["xmas-elf"]
 #hypervisor = ["rvm"]
 
+page-4k = ["kernel-hal/page-4k"]
+page-16k = ["kernel-hal/page-16k"]
+page-64k = ["kernel-hal/page-64k"]
+
 libos = [
     "kernel-hal/libos",
 ]

--- a/zircon-object/src/vm/mod.rs
+++ b/zircon-object/src/vm/mod.rs
@@ -7,7 +7,7 @@ mod vmo;
 pub use self::{stream::*, vmar::*, vmo::*};
 use super::{ZxError, ZxResult};
 use alloc::sync::Arc;
-pub use kernel_hal::{CachePolicy, MMUFlags};
+pub use kernel_hal::{CachePolicy, MMUFlags, PAGE_SIZE, PAGE_SIZE_LOG2};
 use lazy_static::*;
 
 /// Physical Address
@@ -18,12 +18,6 @@ pub type VirtAddr = usize;
 
 /// Device Address
 pub type DevVAddr = usize;
-
-/// Size of a page
-pub const PAGE_SIZE: usize = 0x1000;
-
-/// log2(PAGE_SIZE)
-pub const PAGE_SIZE_LOG2: usize = 12;
 
 /// Check whether `x` is a multiple of `PAGE_SIZE`.
 pub fn page_aligned(x: usize) -> bool {

--- a/zircon-object/src/vm/vmar.rs
+++ b/zircon-object/src/vm/vmar.rs
@@ -767,7 +767,7 @@ impl VmMapping {
                 //通过GenericPageTable的hal_pt_map进行页表映射
                 page_table
                     .map(
-                        Page::new_aligned(inner.addr + i * PAGE_SIZE, PageSize::Size4K),
+                        Page::new_aligned(inner.addr + i * PAGE_SIZE, PageSize::BASE),
                         paddr,
                         inner.flags[i],
                     )

--- a/zircon-object/src/vm/vmo/paged.rs
+++ b/zircon-object/src/vm/vmo/paged.rs
@@ -250,7 +250,7 @@ impl VMObjectTrait for VMObjectPaged {
         let iter = BlockIter {
             begin: offset,
             end: offset + len,
-            block_size_log2: 12,
+            block_size_log2: PAGE_SIZE_LOG2 as u8,
         };
         let mut unwanted = VecDeque::new();
         for block in iter {
@@ -507,7 +507,7 @@ impl VMObjectPagedInner {
         let iter = BlockIter {
             begin: offset,
             end: offset + buf_len,
-            block_size_log2: 12,
+            block_size_log2: PAGE_SIZE_LOG2 as u8,
         };
         for block in iter {
             let paddr = self.commit_page(block.block, flags)?;


### PR DESCRIPTION
This is required to get zCore to boot on a physical device such as an Apple M2 Pro via Asahi U-Boot. I haven't been able to fully test these changes on a physical device yet - so it may need extra testing to make sure it still boots  on older CPUs such as the Cortex A53 outside of qemu as those cpus don't support 16K page sizes.

The good news is `cargo xtask qemu --arch aarch64` seems to work fine, and with my additional changes to make the machine and cpu in QEMU configurable it also boots with `cargo xtask qemu --arch aarch64 --features page-16k`