### PR TITLE
feat(libos): allow overriding rootfs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,15 @@ cargo image --arch riscv64
 cargo linux-libos --args "/bin/busybox"
 ```
 
+默认使用仓库下的 `rootfs/libos` 作为根文件系统。可以通过
+`ZCORE_LIBOS_ROOTFS` 指定其他目录：
+
+```bash
+ZCORE_LIBOS_ROOTFS=/path/to/rootfs cargo linux-libos --args "/bin/busybox"
+```
+
+`ZCORE_LIBOS_ROOTFS` 应指向包含 `bin`、`lib` 等目录的根文件系统目录。
+
 可以直接给应用程序传参数：
 
 ```bash

--- a/zCore/src/fs.rs
+++ b/zCore/src/fs.rs
@@ -6,12 +6,17 @@ cfg_if! {
         #[cfg(feature = "libos")]
         #[cfg_attr(feature = "zircon", allow(dead_code))]
         pub fn rootfs() -> Arc<dyn FileSystem> {
-            let  rootfs = if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
-                std::path::Path::new(&dir).parent().unwrap().to_path_buf()
-            } else {
-                std::env::current_dir().unwrap()
-            };
-            rcore_fs_hostfs::HostFS::new(rootfs.join("rootfs").join("libos"))
+            let rootfs = std::env::var_os("ZCORE_LIBOS_ROOTFS")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| {
+                    let workspace = if let Ok(dir) = std::env::var("CARGO_MANIFEST_DIR") {
+                        std::path::Path::new(&dir).parent().unwrap().to_path_buf()
+                    } else {
+                        std::env::current_dir().unwrap()
+                    };
+                    workspace.join("rootfs").join("libos")
+                });
+            rcore_fs_hostfs::HostFS::new(rootfs)
         }
 
         #[cfg(not(feature = "libos"))]


### PR DESCRIPTION
## Summary

- allow Linux LibOS users to override the host root filesystem with `ZCORE_LIBOS_ROOTFS`
- keep `rootfs/libos` as the default when the variable is unset
- document the override and expected directory layout

## Motivation

LibOS workflows such as fuzzing may maintain a separate rootfs or corpus tree. The current implementation derives the rootfs only from `CARGO_MANIFEST_DIR`, so using another rootfs requires source changes.

## Testing

- `git diff --check`
- static review confirmed the branch contains exactly one commit and modifies only `README.md` and `zCore/src/fs.rs`
- not run locally: Rust build/tests, because a Rust toolchain is not installed in the local environment; GitHub Actions will provide full coverage
